### PR TITLE
feat: enhance product catalog and shopping list builder

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -18,14 +18,14 @@ class ProductController extends Controller
 {
     public function index(Request $request): View
     {
-        $letter = $request->string('letter')->toString();
+        $search = $request->string('search')->toString();
 
         $productsQuery = Product::query()
             ->with(['category', 'inventoryItems.supermarket', 'inventoryItems.section'])
             ->orderBy('name');
 
-        if ($letter) {
-            $productsQuery->where('name', 'like', $letter . '%');
+        if ($search !== '') {
+            $productsQuery->where('name', 'like', '%' . $search . '%');
         }
 
         $products = $productsQuery->get();
@@ -88,7 +88,7 @@ class ProductController extends Controller
             'products' => $products,
             'categories' => $categories,
             'supermarkets' => $supermarkets,
-            'filterLetter' => $letter,
+            'searchTerm' => $search,
             'productDataset' => $productDataset,
             'sectionDataset' => $sectionDataset,
             'activeLists' => $activeLists,
@@ -170,7 +170,7 @@ class ProductController extends Controller
         }
 
         return redirect()
-            ->route('products.index', ['letter' => $request->input('letter')])
+            ->route('products.index', ['search' => $request->input('search')])
             ->with('status', 'Producto actualizado.');
     }
 
@@ -179,7 +179,7 @@ class ProductController extends Controller
         $product->delete();
 
         return redirect()
-            ->route('products.index', ['letter' => $request->input('letter')])
+            ->route('products.index', ['search' => $request->input('search')])
             ->with('status', 'Producto eliminado.');
     }
 
@@ -220,7 +220,7 @@ class ProductController extends Controller
         });
 
         return redirect()
-            ->route('products.index', ['letter' => $request->input('letter')])
+            ->route('products.index', ['search' => $request->input('search')])
             ->with('status', 'Pasillos actualizados.');
     }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\InventoryItem;
+use App\Models\Product;
+use App\Models\ProductCategory;
+use App\Models\ShoppingList;
+use App\Models\Supermarket;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class ProductController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $letter = $request->string('letter')->toString();
+
+        $productsQuery = Product::query()
+            ->with(['category', 'inventoryItems.supermarket', 'inventoryItems.section'])
+            ->orderBy('name');
+
+        if ($letter) {
+            $productsQuery->where('name', 'like', $letter . '%');
+        }
+
+        $products = $productsQuery->get();
+
+        $categories = ProductCategory::orderBy('name')->get();
+        $supermarkets = Supermarket::with(['sections' => fn ($query) => $query->orderBy('position')->orderBy('name')])
+            ->orderBy('name')
+            ->get();
+
+        $productDataset = $products->map(function ($product) {
+            return [
+                'id' => $product->id,
+                'name' => $product->name,
+                'brand' => $product->brand,
+                'unit' => $product->unit,
+                'package_size' => $product->package_size,
+                'average_price' => $product->average_price,
+                'description' => $product->description,
+                'category_id' => $product->product_category_id,
+                'product_category_id' => $product->product_category_id,
+                'inventory' => $product->inventoryItems->map(function ($item) {
+                    return [
+                        'supermarket_id' => $item->supermarket_id,
+                        'supermarket_name' => optional($item->supermarket)->name,
+                        'section_id' => $item->supermarket_section_id,
+                        'section_name' => optional($item->section)->name,
+                        'section_position' => optional($item->section)->position,
+                    ];
+                })->values(),
+            ];
+        })->values();
+
+        $sectionDataset = $supermarkets->flatMap(function ($market) {
+            return $market->sections->map(function ($section) {
+                return [
+                    'id' => $section->id,
+                    'name' => $section->name,
+                    'position' => $section->position,
+                    'supermarket_id' => $section->supermarket_id,
+                ];
+            });
+        })->values();
+
+        $activeLists = $request->user()->shoppingLists()
+            ->with('supermarket')
+            ->where('status', 'active')
+            ->orderBy('name')
+            ->get();
+
+        $activeListsDataset = $activeLists->map(function (ShoppingList $list) {
+            return [
+                'id' => $list->id,
+                'name' => $list->name,
+                'supermarket_id' => $list->supermarket_id,
+                'supermarket_name' => optional($list->supermarket)->name,
+            ];
+        })->values();
+
+        return view('products.index', [
+            'products' => $products,
+            'categories' => $categories,
+            'supermarkets' => $supermarkets,
+            'filterLetter' => $letter,
+            'productDataset' => $productDataset,
+            'sectionDataset' => $sectionDataset,
+            'activeLists' => $activeLists,
+            'activeListsDataset' => $activeListsDataset,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'product_category_id' => ['required', 'exists:product_categories,id'],
+            'brand' => ['nullable', 'string', 'max:255'],
+            'unit' => ['nullable', 'string', 'max:50'],
+            'package_size' => ['nullable', 'string', 'max:255'],
+            'average_price' => ['nullable', 'numeric', 'min:0'],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $slug = Str::slug($data['name']);
+
+        $existing = Product::where('slug', $slug)->exists();
+
+        if ($existing) {
+            $slug .= '-' . Str::random(6);
+        }
+
+        Product::create([
+            'product_category_id' => $data['product_category_id'],
+            'name' => $data['name'],
+            'slug' => $slug,
+            'brand' => Arr::get($data, 'brand'),
+            'unit' => Arr::get($data, 'unit'),
+            'package_size' => Arr::get($data, 'package_size'),
+            'average_price' => Arr::get($data, 'average_price'),
+            'description' => Arr::get($data, 'description'),
+        ]);
+
+        return redirect()
+            ->route('products.index')
+            ->with('status', 'Producto creado correctamente.');
+    }
+
+    public function update(Request $request, Product $product): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'product_category_id' => ['required', 'exists:product_categories,id'],
+            'brand' => ['nullable', 'string', 'max:255'],
+            'unit' => ['nullable', 'string', 'max:50'],
+            'package_size' => ['nullable', 'string', 'max:255'],
+            'average_price' => ['nullable', 'numeric', 'min:0'],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $product->fill($data);
+
+        if ($product->isDirty('name')) {
+            $product->slug = Str::slug($data['name']);
+        }
+
+        $product->save();
+
+        if ($request->expectsJson()) {
+            $product->refresh();
+
+            return response()->json([
+                'product' => [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'brand' => $product->brand,
+                    'unit' => $product->unit,
+                    'package_size' => $product->package_size,
+                    'average_price' => $product->average_price,
+                    'description' => $product->description,
+                    'product_category_id' => $product->product_category_id,
+                ],
+            ]);
+        }
+
+        return redirect()
+            ->route('products.index', ['letter' => $request->input('letter')])
+            ->with('status', 'Producto actualizado.');
+    }
+
+    public function destroy(Request $request, Product $product): RedirectResponse
+    {
+        $product->delete();
+
+        return redirect()
+            ->route('products.index', ['letter' => $request->input('letter')])
+            ->with('status', 'Producto eliminado.');
+    }
+
+    public function updateSections(Request $request, Product $product): RedirectResponse
+    {
+        $data = $request->validate([
+            'sections' => ['array'],
+            'sections.*.supermarket_id' => ['required', 'exists:supermarkets,id'],
+            'sections.*.section_id' => ['nullable', 'exists:supermarket_sections,id'],
+        ]);
+
+        $sections = collect($data['sections'] ?? [])
+            ->map(fn ($item) => [
+                'supermarket_id' => (int) $item['supermarket_id'],
+                'section_id' => $item['section_id'] ? (int) $item['section_id'] : null,
+            ]);
+
+        DB::transaction(function () use ($product, $sections) {
+            $inventoryItems = $product->inventoryItems()->get()->keyBy('supermarket_id');
+
+            foreach ($sections as $entry) {
+                $supermarketId = $entry['supermarket_id'];
+                $sectionId = $entry['section_id'];
+                $inventoryItem = $inventoryItems->get($supermarketId);
+
+                if ($inventoryItem) {
+                    $inventoryItem->update([
+                        'supermarket_section_id' => $sectionId,
+                    ]);
+                } else {
+                    InventoryItem::create([
+                        'product_id' => $product->id,
+                        'supermarket_id' => $supermarketId,
+                        'supermarket_section_id' => $sectionId,
+                    ]);
+                }
+            }
+        });
+
+        return redirect()
+            ->route('products.index', ['letter' => $request->input('letter')])
+            ->with('status', 'Pasillos actualizados.');
+    }
+}

--- a/app/Http/Controllers/ShoppingListController.php
+++ b/app/Http/Controllers/ShoppingListController.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use JsonException;
+use Illuminate\Validation\Rule;
 
 class ShoppingListController extends Controller
 {
@@ -37,7 +38,9 @@ class ShoppingListController extends Controller
         $supermarkets = Supermarket::with(['sections' => fn ($query) => $query->orderBy('position')->orderBy('name')])
             ->orderBy('name')
             ->get();
-        $products = Product::with('category')->orderBy('name')->get();
+        $products = Product::with(['category', 'inventoryItems.supermarket', 'inventoryItems.section'])
+            ->orderBy('name')
+            ->get();
         $categories = ProductCategory::orderBy('name')->get();
 
         $productDataset = $products->map(function ($product) {
@@ -47,6 +50,19 @@ class ShoppingListController extends Controller
                 'unit' => $product->unit,
                 'brand' => $product->brand,
                 'category_id' => $product->product_category_id,
+                'product_category_id' => $product->product_category_id,
+                'package_size' => $product->package_size,
+                'average_price' => $product->average_price,
+                'description' => $product->description,
+                'inventory' => $product->inventoryItems->map(function ($item) {
+                    return [
+                        'supermarket_id' => $item->supermarket_id,
+                        'supermarket_name' => optional($item->supermarket)->name,
+                        'section_id' => $item->supermarket_section_id,
+                        'section_name' => optional($item->section)->name,
+                        'section_position' => optional($item->section)->position,
+                    ];
+                })->values(),
             ];
         })->values();
 
@@ -87,6 +103,7 @@ class ShoppingListController extends Controller
             'planned_for' => ['nullable', 'date'],
             'notes' => ['nullable', 'string'],
             'items' => ['required', 'string'],
+            'status' => ['required', Rule::in(['active', 'draft'])],
         ]);
 
         try {
@@ -111,7 +128,7 @@ class ShoppingListController extends Controller
                 'user_id' => $user->id,
                 'supermarket_id' => $defaultSupermarketId,
                 'name' => $data['name'],
-                'status' => 'active',
+                'status' => $data['status'],
                 'budget' => Arr::get($data, 'budget'),
                 'estimated_total' => 0,
                 'planned_for' => Arr::get($data, 'planned_for') ? Carbon::parse($data['planned_for']) : null,
@@ -156,6 +173,21 @@ class ShoppingListController extends Controller
         return redirect()
             ->route('shopping-lists.show', $shoppingList)
             ->with('status', 'Lista creada y lista para ir de compras.');
+    }
+
+    public function update(Request $request, ShoppingList $shoppingList): RedirectResponse
+    {
+        if ($shoppingList->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'status' => ['required', Rule::in(['active', 'draft'])],
+        ]);
+
+        $shoppingList->update(['status' => $data['status']]);
+
+        return back()->with('status', 'Estado de la lista actualizado.');
     }
 
     public function addItems(Request $request, ShoppingList $shoppingList): RedirectResponse
@@ -306,7 +338,9 @@ class ShoppingListController extends Controller
         $supermarkets = Supermarket::with(['sections' => fn ($query) => $query->orderBy('position')->orderBy('name')])
             ->orderBy('name')
             ->get();
-        $products = Product::with('category')->orderBy('name')->get();
+        $products = Product::with(['category', 'inventoryItems.supermarket', 'inventoryItems.section'])
+            ->orderBy('name')
+            ->get();
         $categories = ProductCategory::orderBy('name')->get();
 
         $productDataset = $products->map(function ($product) {
@@ -316,6 +350,19 @@ class ShoppingListController extends Controller
                 'unit' => $product->unit,
                 'brand' => $product->brand,
                 'category_id' => $product->product_category_id,
+                'product_category_id' => $product->product_category_id,
+                'package_size' => $product->package_size,
+                'average_price' => $product->average_price,
+                'description' => $product->description,
+                'inventory' => $product->inventoryItems->map(function ($item) {
+                    return [
+                        'supermarket_id' => $item->supermarket_id,
+                        'supermarket_name' => optional($item->supermarket)->name,
+                        'section_id' => $item->supermarket_section_id,
+                        'section_name' => optional($item->section)->name,
+                        'section_position' => optional($item->section)->position,
+                    ];
+                })->values(),
             ];
         })->values();
 

--- a/app/Http/Controllers/ShoppingListController.php
+++ b/app/Http/Controllers/ShoppingListController.php
@@ -177,7 +177,7 @@ class ShoppingListController extends Controller
 
     public function update(Request $request, ShoppingList $shoppingList): RedirectResponse
     {
-        if ($shoppingList->user_id !== $request->user()->id) {
+        if ((int) $shoppingList->user_id !== (int) $request->user()->id) {
             abort(403);
         }
 
@@ -192,7 +192,7 @@ class ShoppingListController extends Controller
 
     public function addItems(Request $request, ShoppingList $shoppingList): RedirectResponse
     {
-        if ($shoppingList->user_id !== $request->user()->id) {
+        if ((int) $shoppingList->user_id !== (int) $request->user()->id) {
             abort(403);
         }
 
@@ -257,7 +257,7 @@ class ShoppingListController extends Controller
 
     public function show(Request $request, ShoppingList $shoppingList): View
     {
-        if ($shoppingList->user_id !== $request->user()->id) {
+        if ((int) $shoppingList->user_id !== (int) $request->user()->id) {
             abort(403);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2432 @@
+{
+    "name": "MarketGo",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "devDependencies": {
+                "@tailwindcss/vite": "^4.0.0",
+                "axios": "^1.11.0",
+                "concurrently": "^9.0.1",
+                "laravel-vite-plugin": "^2.0.0",
+                "tailwindcss": "^4.0.0",
+                "vite": "^7.0.4"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+            "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+            "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+            "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+            "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+            "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+            "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+            "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+            "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+            "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+            "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+            "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+            "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+            "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+            "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+            "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+            "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+            "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+            "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+            "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+            "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+            "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+            "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+            "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+            "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+            "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+            "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+            "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+            "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+            "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+            "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+            "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+            "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+            "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+            "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+            "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+            "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+            "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+            "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+            "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+            "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+            "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@tailwindcss/node": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
+            "integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.4",
+                "enhanced-resolve": "^5.18.3",
+                "jiti": "^2.5.1",
+                "lightningcss": "1.30.1",
+                "magic-string": "^0.30.18",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.1.13"
+            }
+        },
+        "node_modules/@tailwindcss/oxide": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
+            "integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.4",
+                "tar": "^7.4.3"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@tailwindcss/oxide-android-arm64": "4.1.13",
+                "@tailwindcss/oxide-darwin-arm64": "4.1.13",
+                "@tailwindcss/oxide-darwin-x64": "4.1.13",
+                "@tailwindcss/oxide-freebsd-x64": "4.1.13",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.1.13",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.1.13",
+                "@tailwindcss/oxide-linux-x64-musl": "4.1.13",
+                "@tailwindcss/oxide-wasm32-wasi": "4.1.13",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.1.13"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-android-arm64": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.13.tgz",
+            "integrity": "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-arm64": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.13.tgz",
+            "integrity": "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-x64": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.13.tgz",
+            "integrity": "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-freebsd-x64": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.13.tgz",
+            "integrity": "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.13.tgz",
+            "integrity": "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.13.tgz",
+            "integrity": "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.13.tgz",
+            "integrity": "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.13.tgz",
+            "integrity": "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.13.tgz",
+            "integrity": "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.13.tgz",
+            "integrity": "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.5",
+                "@emnapi/runtime": "^1.4.5",
+                "@emnapi/wasi-threads": "^1.0.4",
+                "@napi-rs/wasm-runtime": "^0.2.12",
+                "@tybys/wasm-util": "^0.10.0",
+                "tslib": "^2.8.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
+            "integrity": "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.13.tgz",
+            "integrity": "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/vite": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.13.tgz",
+            "integrity": "sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tailwindcss/node": "4.1.13",
+                "@tailwindcss/oxide": "4.1.13",
+                "tailwindcss": "4.1.13"
+            },
+            "peerDependencies": {
+                "vite": "^5.2.0 || ^6 || ^7"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/concurrently": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+            "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "4.1.2",
+                "rxjs": "7.8.2",
+                "shell-quote": "1.8.3",
+                "supports-color": "8.1.1",
+                "tree-kill": "1.2.2",
+                "yargs": "17.7.2"
+            },
+            "bin": {
+                "conc": "dist/bin/concurrently.js",
+                "concurrently": "dist/bin/concurrently.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+            "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+            "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+            "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.10",
+                "@esbuild/android-arm": "0.25.10",
+                "@esbuild/android-arm64": "0.25.10",
+                "@esbuild/android-x64": "0.25.10",
+                "@esbuild/darwin-arm64": "0.25.10",
+                "@esbuild/darwin-x64": "0.25.10",
+                "@esbuild/freebsd-arm64": "0.25.10",
+                "@esbuild/freebsd-x64": "0.25.10",
+                "@esbuild/linux-arm": "0.25.10",
+                "@esbuild/linux-arm64": "0.25.10",
+                "@esbuild/linux-ia32": "0.25.10",
+                "@esbuild/linux-loong64": "0.25.10",
+                "@esbuild/linux-mips64el": "0.25.10",
+                "@esbuild/linux-ppc64": "0.25.10",
+                "@esbuild/linux-riscv64": "0.25.10",
+                "@esbuild/linux-s390x": "0.25.10",
+                "@esbuild/linux-x64": "0.25.10",
+                "@esbuild/netbsd-arm64": "0.25.10",
+                "@esbuild/netbsd-x64": "0.25.10",
+                "@esbuild/openbsd-arm64": "0.25.10",
+                "@esbuild/openbsd-x64": "0.25.10",
+                "@esbuild/openharmony-arm64": "0.25.10",
+                "@esbuild/sunos-x64": "0.25.10",
+                "@esbuild/win32-arm64": "0.25.10",
+                "@esbuild/win32-ia32": "0.25.10",
+                "@esbuild/win32-x64": "0.25.10"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jiti": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
+            "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/laravel-vite-plugin": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.0.1.tgz",
+            "integrity": "sha512-zQuvzWfUKQu9oNVi1o0RZAJCwhGsdhx4NEOyrVQwJHaWDseGP9tl7XUPLY2T8Cj6+IrZ6lmyxlR1KC8unf3RLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^7.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+            "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-darwin-arm64": "1.30.1",
+                "lightningcss-darwin-x64": "1.30.1",
+                "lightningcss-freebsd-x64": "1.30.1",
+                "lightningcss-linux-arm-gnueabihf": "1.30.1",
+                "lightningcss-linux-arm64-gnu": "1.30.1",
+                "lightningcss-linux-arm64-musl": "1.30.1",
+                "lightningcss-linux-x64-gnu": "1.30.1",
+                "lightningcss-linux-x64-musl": "1.30.1",
+                "lightningcss-win32-arm64-msvc": "1.30.1",
+                "lightningcss-win32-x64-msvc": "1.30.1"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+            "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+            "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+            "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+            "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+            "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+            "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+            "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+            "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+            "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+            "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.19",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+            "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.52.2",
+                "@rollup/rollup-android-arm64": "4.52.2",
+                "@rollup/rollup-darwin-arm64": "4.52.2",
+                "@rollup/rollup-darwin-x64": "4.52.2",
+                "@rollup/rollup-freebsd-arm64": "4.52.2",
+                "@rollup/rollup-freebsd-x64": "4.52.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+                "@rollup/rollup-linux-arm64-musl": "4.52.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-musl": "4.52.2",
+                "@rollup/rollup-openharmony-arm64": "4.52.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+                "@rollup/rollup-win32-x64-gnu": "4.52.2",
+                "@rollup/rollup-win32-x64-msvc": "4.52.2",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+            "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tapable": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
+            "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tar": {
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+            "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/vite": {
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
+            "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.25.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-full-reload": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+            "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        }
+    }
+}

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,11 +1,16 @@
 {
-    "resources/js/app.js": {
-        "file": "app.js",
-        "src": "resources/js/app.js",
-        "isEntry": true
-    },
-    "resources/css/app.css": {
-        "file": "app.css",
-        "src": "resources/css/app.css"
-    }
+  "resources/css/app.css": {
+    "file": "assets/app-OwH5Uahm.css",
+    "src": "resources/css/app.css",
+    "isEntry": true,
+    "names": [
+      "app.css"
+    ]
+  },
+  "resources/js/app.js": {
+    "file": "assets/app-Dw4r-28f.js",
+    "name": "app",
+    "src": "resources/js/app.js",
+    "isEntry": true
+  }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,39 +1,459 @@
 import './bootstrap';
 
+class ProductCatalog {
+    constructor(root) {
+        this.root = root;
+        this.products = this.parseDataset(root.dataset.products);
+        this.lists = this.parseDataset(root.dataset.lists);
+        this.sections = this.parseDataset(root.dataset.sections);
+        this.productById = new Map(this.products.map((product) => [product.id, product]));
+        this.listById = new Map(this.lists.map((list) => [list.id, list]));
+        this.sectionById = new Map(this.sections.map((section) => [section.id, section]));
+        this.sectionsBySupermarket = this.buildSectionsIndex();
+
+        this.modal = document.querySelector('[data-modal="product-add"]');
+        this.form = this.modal?.querySelector('[data-product-add-form]');
+        this.itemsInput = this.form?.querySelector('[data-add-items]');
+        this.listSelect = this.form?.querySelector('[data-add-list]');
+        this.quantityInput = this.form?.querySelector('[data-add-quantity]');
+        this.priceInput = this.form?.querySelector('[data-add-price]');
+        this.notesInput = this.form?.querySelector('[data-add-notes]');
+        this.sectionSelect = this.form?.querySelector('[data-add-section]');
+        this.summaryNode = this.form?.querySelector('[data-add-summary]');
+        this.productNameNode = this.form?.querySelector('[data-add-product-name]');
+        this.productMetaNode = this.form?.querySelector('[data-add-product-meta]');
+        this.productDescriptionNode = this.form?.querySelector('[data-add-product-description]');
+        this.unitBadge = this.form?.querySelector('[data-add-unit]');
+        this.sectionHint = this.form?.querySelector('[data-add-section-hint]');
+        this.submitButton = this.form?.querySelector('[data-add-submit]');
+        this.bodyContainer = this.form?.querySelector('[data-add-body]');
+        this.emptyContainer = this.form?.querySelector('[data-add-empty]');
+        this.actionTemplate = this.form?.dataset.actionTemplate ?? '';
+        this.currentProduct = null;
+
+        this.bindEvents();
+    }
+
+    parseDataset(value) {
+        if (! value) {
+            return [];
+        }
+
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            console.warn('No se pudo interpretar el dataset del catálogo', error);
+            return [];
+        }
+    }
+
+    buildSectionsIndex() {
+        const index = new Map();
+
+        this.sections.forEach((section) => {
+            const list = index.get(section.supermarket_id) ?? [];
+            list.push(section);
+            index.set(section.supermarket_id, list);
+        });
+
+        return index;
+    }
+
+    bindEvents() {
+        this.root.querySelectorAll('[data-action="open-add"]').forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+
+                const card = button.closest('[data-product-card]');
+                const productId = this.parseNullableInt(button.dataset.productId ?? card?.dataset.productId ?? null);
+
+                if (productId) {
+                    this.openModalForProduct(productId);
+                }
+            });
+        });
+
+        if (this.listSelect) {
+            this.listSelect.addEventListener('change', () => {
+                this.handleListChange();
+            });
+        }
+
+        this.sectionSelect?.addEventListener('change', () => this.updateItemsPayload());
+        this.quantityInput?.addEventListener('input', () => this.updateItemsPayload());
+        this.priceInput?.addEventListener('input', () => this.updateItemsPayload());
+        this.notesInput?.addEventListener('input', () => this.updateItemsPayload());
+
+        this.form?.addEventListener('submit', (event) => {
+            const payload = this.buildPayload();
+
+            if (! payload) {
+                event.preventDefault();
+                alert('Selecciona una lista activa antes de continuar.');
+                return false;
+            }
+
+            this.syncItemsInput(payload);
+
+            return true;
+        });
+    }
+
+    openModalForProduct(productId) {
+        const product = this.productById.get(productId);
+
+        if (! product || ! this.modal || ! this.form) {
+            return;
+        }
+
+        this.currentProduct = product;
+        this.resetFormState(product);
+        this.populateListOptions();
+        this.updateProductDetails(product);
+        this.handleListChange();
+        this.modal.classList.remove('hidden');
+    }
+
+    resetFormState(product) {
+        if (this.listSelect) {
+            this.listSelect.value = '';
+        }
+
+        if (this.quantityInput) {
+            this.quantityInput.value = '1';
+        }
+
+        if (this.priceInput) {
+            this.priceInput.value = product?.average_price ?? '';
+        }
+
+        if (this.notesInput) {
+            this.notesInput.value = '';
+        }
+
+        if (this.sectionSelect) {
+            this.sectionSelect.innerHTML = '';
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = 'Sin pasillo asignado';
+            this.sectionSelect.appendChild(placeholder);
+        }
+
+        if (this.summaryNode) {
+            this.summaryNode.textContent = 'Selecciona una lista activa para preparar el envío del producto.';
+        }
+    }
+
+    populateListOptions() {
+        if (! this.listSelect) {
+            return;
+        }
+
+        this.listSelect.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = '-- Selecciona una lista --';
+        this.listSelect.appendChild(placeholder);
+
+        this.lists.forEach((list) => {
+            const option = document.createElement('option');
+            option.value = list.id;
+            option.textContent = list.supermarket_name
+                ? `${list.name} · ${list.supermarket_name}`
+                : list.name;
+            this.listSelect?.appendChild(option);
+        });
+    }
+
+    updateProductDetails(product) {
+        if (this.productNameNode) {
+            this.productNameNode.textContent = product.name;
+        }
+
+        const unit = product.unit ?? 'Sin unidad';
+        const brand = product.brand ?? 'Sin marca';
+
+        if (this.productMetaNode) {
+            this.productMetaNode.textContent = `${brand} · ${unit}`;
+        }
+
+        if (this.productDescriptionNode) {
+            const description = product.description ?? 'Sin descripción registrada.';
+            this.productDescriptionNode.textContent = description;
+        }
+
+        if (this.unitBadge) {
+            this.unitBadge.textContent = product.unit ?? 'Unidad';
+        }
+    }
+
+    handleListChange() {
+        if (! this.listSelect) {
+            return;
+        }
+
+        const listId = this.parseNullableInt(this.listSelect.value);
+        const list = listId ? this.listById.get(listId) : null;
+
+        if (! list) {
+            this.updateSectionOptions(null);
+            this.updateItemsPayload();
+            this.updateFormAvailability(false);
+            return;
+        }
+
+        this.updateSectionOptions(list);
+        this.updateItemsPayload();
+        this.updateFormAvailability(true);
+    }
+
+    updateSectionOptions(list) {
+        if (! this.sectionSelect) {
+            return;
+        }
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Sin pasillo asignado';
+
+        this.sectionSelect.innerHTML = '';
+        this.sectionSelect.appendChild(placeholder);
+
+        if (! list) {
+            this.sectionSelect.disabled = true;
+
+            if (this.sectionHint) {
+                this.sectionHint.textContent = 'Selecciona una lista activa para ver los pasillos disponibles.';
+            }
+
+            return;
+        }
+
+        if (! list.supermarket_id) {
+            this.sectionSelect.disabled = true;
+
+            if (this.sectionHint) {
+                this.sectionHint.textContent = 'Asigna un establecimiento predeterminado en la lista para elegir pasillos.';
+            }
+
+        } else {
+            this.sectionSelect.disabled = false;
+
+            const sections = this.sectionsBySupermarket.get(list.supermarket_id) ?? [];
+            const defaultEntry = this.currentProduct
+                ? this.getInventoryEntry(this.currentProduct.id, list.supermarket_id)
+                : null;
+
+            sections.forEach((section) => {
+                const option = document.createElement('option');
+                option.value = section.id;
+                option.textContent = this.formatSection(section);
+
+                if (defaultEntry?.section_id && defaultEntry.section_id === section.id) {
+                    option.selected = true;
+                }
+
+                this.sectionSelect?.appendChild(option);
+            });
+
+            if (defaultEntry?.section_id && this.sectionSelect && ! this.sectionSelect.value) {
+                this.sectionSelect.value = String(defaultEntry.section_id);
+            }
+
+            if (this.sectionHint) {
+                this.sectionHint.textContent = list.supermarket_name
+                    ? `Pasillos del establecimiento ${list.supermarket_name}.`
+                    : 'Selecciona un pasillo disponible para esta lista.';
+            }
+        }
+    }
+
+    updateFormAvailability(isReady) {
+        const hasLists = this.lists.length > 0;
+
+        if (this.submitButton) {
+            this.submitButton.disabled = ! isReady;
+            this.submitButton.classList.toggle('opacity-60', ! isReady);
+        }
+
+        if (this.bodyContainer) {
+            this.bodyContainer.classList.toggle('hidden', ! hasLists);
+        }
+
+        if (this.emptyContainer) {
+            this.emptyContainer.classList.toggle('hidden', hasLists);
+        }
+
+        if (! isReady && hasLists && this.summaryNode) {
+            this.summaryNode.textContent = 'Selecciona una lista activa para preparar el envío del producto.';
+        }
+    }
+
+    updateItemsPayload() {
+        const payload = this.buildPayload();
+
+        if (payload) {
+            this.syncItemsInput(payload);
+            this.updateSummary(payload);
+        } else if (this.itemsInput) {
+            this.itemsInput.value = '[]';
+        }
+    }
+
+    buildPayload() {
+        if (! this.currentProduct || ! this.listSelect) {
+            return null;
+        }
+
+        const listId = this.parseNullableInt(this.listSelect.value);
+        const list = listId ? this.listById.get(listId) : null;
+
+        if (! list) {
+            return null;
+        }
+
+        const quantity = this.quantityInput ? Number.parseFloat(this.quantityInput.value || '1') || 1 : 1;
+        const price = this.priceInput ? this.parsePrice(this.priceInput.value) : null;
+        const notes = this.notesInput?.value?.trim() || null;
+        const sectionId = this.sectionSelect ? this.parseNullableInt(this.sectionSelect.value) : null;
+        const sectionData = sectionId ? this.sectionById.get(sectionId) : null;
+        const inventoryEntry = this.getInventoryEntry(this.currentProduct.id, list.supermarket_id);
+
+        return {
+            type: 'existing',
+            product_id: this.currentProduct.id,
+            product_name: this.currentProduct.name,
+            name: this.currentProduct.name,
+            brand: this.currentProduct.brand ?? null,
+            product_category_id: this.currentProduct.product_category_id ?? this.currentProduct.category_id ?? null,
+            package_size: this.currentProduct.package_size ?? null,
+            unit: this.currentProduct.unit ?? '',
+            quantity,
+            quantity_unit: this.currentProduct.unit ?? '',
+            estimated_price: price ?? null,
+            supermarket_id: list.supermarket_id ?? null,
+            supermarket_name: list.supermarket_name ?? null,
+            section_id: sectionId ?? inventoryEntry?.section_id ?? null,
+            section_name: sectionData?.name ?? inventoryEntry?.section_name ?? null,
+            section_number: sectionData?.position ?? inventoryEntry?.section_position ?? null,
+            notes,
+            description: this.currentProduct.description ?? null,
+        };
+    }
+
+    syncItemsInput(payload) {
+        if (this.itemsInput) {
+            this.itemsInput.value = JSON.stringify([payload]);
+        }
+
+        if (this.form && this.actionTemplate) {
+            const listId = this.parseNullableInt(this.listSelect?.value ?? null);
+
+            if (listId) {
+                this.form.action = this.actionTemplate.replace('__LIST__', String(listId));
+            }
+        }
+    }
+
+    updateSummary(payload) {
+        if (! this.summaryNode) {
+            return;
+        }
+
+        const supermarket = payload.supermarket_name ?? 'Sin establecimiento principal';
+        const sectionLabel = payload.section_number
+            ? `Pasillo ${payload.section_number}${payload.section_name ? ` · ${payload.section_name}` : ''}`
+            : (payload.section_name ?? 'Sin pasillo asignado');
+
+        this.summaryNode.textContent = `Se agregará ${payload.quantity} ${payload.quantity_unit || ''} de ${payload.product_name} a ${supermarket}. Ubicación: ${sectionLabel}.`;
+    }
+
+    getInventoryEntry(productId, supermarketId) {
+        if (! productId) {
+            return null;
+        }
+
+        const product = this.productById.get(productId);
+
+        if (! product || ! Array.isArray(product.inventory)) {
+            return null;
+        }
+
+        if (supermarketId) {
+            const match = product.inventory.find((entry) => entry.supermarket_id === supermarketId);
+
+            if (match) {
+                return match;
+            }
+        }
+
+        return product.inventory[0] ?? null;
+    }
+
+    formatSection(section) {
+        if (section.position !== null && section.position !== undefined) {
+            return section.name ? `Pasillo ${section.position} · ${section.name}` : `Pasillo ${section.position}`;
+        }
+
+        return section.name ?? 'Sin pasillo';
+    }
+
+    parseNullableInt(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        const parsed = Number.parseInt(value, 10);
+
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+
+    parsePrice(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        const parsed = Number.parseFloat(value);
+
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+}
+
 class ListBuilder {
     constructor(root) {
         this.root = root;
         this.itemsInput = document.getElementById('items-input');
-        this.itemsTable = root.querySelector('[data-items-table]');
+        this.displayMode = root.dataset.displayMode ?? 'inline';
         this.products = this.parseDataset(root.dataset.products);
         this.supermarkets = this.parseDataset(root.dataset.supermarkets);
         this.sections = this.parseDataset(root.dataset.sections);
+        this.productById = new Map(this.products.map((product) => [product.id, product]));
         this.supermarketById = new Map(this.supermarkets.map((market) => [market.id, market]));
         this.sectionById = new Map(this.sections.map((section) => [section.id, section]));
+        this.sectionsBySupermarket = this.buildSectionsIndex();
+
+        this.queueContainer = root.querySelector('[data-items-queue]');
+        this.emptyPlaceholder = this.queueContainer?.querySelector('[data-empty-placeholder]') ?? null;
+        this.itemTemplate = root.querySelector('[data-item-template]');
         this.items = this.parseInitialItems(this.itemsInput?.value ?? '[]');
 
-        this.elements = {
-            existingProduct: root.querySelector('[data-existing-product]'),
-            existingQuantity: root.querySelector('[data-existing-quantity]'),
-            existingUnit: root.querySelector('[data-existing-unit]'),
-            existingPrice: root.querySelector('[data-existing-price]'),
-            existingSupermarket: root.querySelector('[data-existing-supermarket]'),
-            existingSection: root.querySelector('[data-existing-section]'),
-            existingSectionNumber: root.querySelector('[data-existing-section-number]'),
-            existingSectionName: root.querySelector('[data-existing-section-name]'),
-            addExistingButton: root.querySelector('[data-action="add-existing"]'),
-            manualName: root.querySelector('[data-manual-name]'),
-            manualUnit: root.querySelector('[data-manual-unit]'),
-            manualBrand: root.querySelector('[data-manual-brand]'),
-            manualCategory: root.querySelector('[data-manual-category]'),
-            manualQuantity: root.querySelector('[data-manual-quantity]'),
-            manualPrice: root.querySelector('[data-manual-price]'),
-            manualSupermarket: root.querySelector('[data-manual-supermarket]'),
-            manualSectionNumber: root.querySelector('[data-manual-section-number]'),
-            manualSectionName: root.querySelector('[data-manual-section-name]'),
-            manualNotes: root.querySelector('[data-manual-notes]'),
-            addManualButton: root.querySelector('[data-action="add-manual"]'),
-        };
+        this.existingForms = this.collectExistingForms();
+        this.manualForms = this.collectManualForms();
+        this.modals = this.collectModals();
+
+        this.defaultSupermarketId = this.parseNullableInt(root.dataset.defaultSupermarket);
+        this.supermarketField = root.dataset.supermarketField
+            ? document.querySelector(root.dataset.supermarketField)
+            : null;
+
+        if (this.supermarketField) {
+            this.supermarketField.addEventListener('change', () => {
+                this.defaultSupermarketId = this.parseNullableInt(this.supermarketField.value);
+                this.manualForms.forEach((form) => this.populateManualSections(form));
+            });
+        }
 
         this.bindEvents();
         this.render();
@@ -60,11 +480,88 @@ class ListBuilder {
         try {
             const parsed = JSON.parse(value);
 
-            return Array.isArray(parsed) ? parsed : [];
+            if (! Array.isArray(parsed)) {
+                return [];
+            }
+
+            return parsed.map((item) => ({
+                ...item,
+                quantity: Number.parseFloat(item.quantity ?? 1) || 1,
+                estimated_price: this.parsePrice(item.estimated_price),
+                quantity_unit: item.quantity_unit ?? item.unit ?? '',
+                supermarket_id: this.parseNullableInt(item.supermarket_id),
+                section_id: this.parseNullableInt(item.section_id),
+                section_number: this.parseNullableInt(item.section_number),
+                notes: item.notes ?? null,
+            }));
         } catch (error) {
             console.warn('No se pudieron leer los productos iniciales', error);
             return [];
         }
+    }
+
+    collectExistingForms() {
+        return Array.from(this.root.querySelectorAll('[data-existing-block]')).map((container) => ({
+            container,
+            select: container.querySelector('[data-existing-product]'),
+            quantity: container.querySelector('[data-existing-quantity]'),
+            notes: container.querySelector('[data-existing-notes]'),
+            filter: container.querySelector('[data-existing-filter]'),
+            letter: container.querySelector('[data-existing-letter]'),
+        }));
+    }
+
+    collectManualForms() {
+        return Array.from(this.root.querySelectorAll('[data-manual-block]')).map((container) => ({
+            container,
+            name: container.querySelector('[data-manual-name]'),
+            unit: container.querySelector('[data-manual-unit]'),
+            brand: container.querySelector('[data-manual-brand]'),
+            quantity: container.querySelector('[data-manual-quantity]'),
+            price: container.querySelector('[data-manual-price]'),
+            supermarket: container.querySelector('[data-manual-supermarket]'),
+            section: container.querySelector('[data-manual-section]'),
+            notes: container.querySelector('[data-manual-notes]'),
+            addButton: container.querySelector('[data-action="add-manual"]'),
+        }));
+    }
+
+    collectModals() {
+        const modals = new Map();
+
+        this.root.querySelectorAll('[data-modal]').forEach((modal) => {
+            const id = modal.dataset.modal;
+
+            if (! id) {
+                return;
+            }
+
+            modals.set(id, modal);
+
+            modal.querySelectorAll('[data-close-modal]').forEach((button) => {
+                button.addEventListener('click', () => this.closeModal(modal));
+            });
+
+            modal.addEventListener('click', (event) => {
+                if (event.target === modal) {
+                    this.closeModal(modal);
+                }
+            });
+        });
+
+        return modals;
+    }
+
+    buildSectionsIndex() {
+        const index = new Map();
+
+        this.sections.forEach((section) => {
+            const list = index.get(section.supermarket_id) ?? [];
+            list.push(section);
+            index.set(section.supermarket_id, list);
+        });
+
+        return index;
     }
 
     bindEvents() {
@@ -84,125 +581,503 @@ class ListBuilder {
             });
         }
 
-        this.elements.addExistingButton?.addEventListener('click', () => this.addExistingItem());
-        this.elements.addManualButton?.addEventListener('click', () => this.addManualItem());
-
-        this.elements.existingProduct?.addEventListener('change', () => {
-            const productId = Number.parseInt(this.elements.existingProduct.value, 10);
-            const product = this.products.find((item) => item.id === productId);
-
-            if (product?.unit && ! this.elements.existingUnit.value) {
-                this.elements.existingUnit.value = product.unit;
-            }
+        this.root.querySelectorAll('[data-action="open-existing"]').forEach((button) => {
+            button.addEventListener('click', () => this.handleOpenExisting());
         });
 
-        this.elements.existingSection?.addEventListener('change', () => {
-            const sectionId = this.parseNullableInt(this.elements.existingSection.value);
-            const section = sectionId ? this.sectionById.get(sectionId) : null;
+        this.root.querySelectorAll('[data-action="open-manual"]').forEach((button) => {
+            button.addEventListener('click', () => this.handleOpenManual());
+        });
 
-            if (! section) {
+        this.existingForms.forEach((form) => {
+            form.select?.addEventListener('change', () => this.handleExistingSelection(form));
+            form.filter?.addEventListener('input', () => this.filterExistingOptions(form));
+            form.letter?.addEventListener('change', () => {
+                this.applyExistingFilters(form);
+
+                if (form.select && form.select.value) {
+                    const selectedOption = form.select.selectedOptions[0];
+
+                    if (selectedOption?.hidden) {
+                        form.select.value = '';
+                    }
+                }
+            });
+
+            this.applyExistingFilters(form);
+        });
+
+        this.manualForms.forEach((form) => {
+            form.addButton?.addEventListener('click', () => this.addManualItem(form));
+            form.supermarket?.addEventListener('change', () => this.populateManualSections(form));
+            this.populateManualSections(form);
+        });
+
+        this.queueContainer?.addEventListener('click', (event) => {
+            const target = event.target;
+
+            if (! (target instanceof HTMLElement)) {
                 return;
             }
 
-            if (this.elements.existingSectionNumber) {
-                this.elements.existingSectionNumber.value = section.position ?? '';
-            }
-
-            if (this.elements.existingSectionName && ! this.elements.existingSectionName.value) {
-                this.elements.existingSectionName.value = section.name ?? '';
-            }
-        });
-
-        this.itemsTable.addEventListener('click', (event) => {
-            const target = event.target;
-
-            if (target instanceof HTMLElement && target.dataset.action === 'remove-item') {
-                const index = Number.parseInt(target.dataset.index, 10);
+            if (target.dataset.action === 'remove-item') {
+                const index = Number.parseInt(target.dataset.index ?? '', 10);
 
                 if (! Number.isNaN(index)) {
                     this.items.splice(index, 1);
                     this.render();
                 }
             }
+
+            if (target.dataset.action === 'edit-item') {
+                const index = Number.parseInt(target.dataset.index ?? '', 10);
+
+                if (! Number.isNaN(index)) {
+                    this.openEditModal(index);
+                }
+            }
         });
     }
 
-    addExistingItem() {
-        const productId = Number.parseInt(this.elements.existingProduct?.value ?? '', 10);
-        const product = this.products.find((item) => item.id === productId);
-
-        if (! product) {
-            alert('Selecciona un producto del catálogo.');
+    handleOpenExisting() {
+        if (this.displayMode === 'modal') {
+            this.openModal('builder-existing');
             return;
         }
 
-        const quantity = Number.parseFloat(this.elements.existingQuantity?.value ?? '1') || 1;
-        const unit = (this.elements.existingUnit?.value || product.unit || '').trim();
-        const estimatedPrice = this.parsePrice(this.elements.existingPrice?.value);
-        const supermarketId = this.parseNullableInt(this.elements.existingSupermarket?.value);
-        const sectionId = this.parseNullableInt(this.elements.existingSection?.value);
-        const sectionNumberInput = this.parseNullableInt(this.elements.existingSectionNumber?.value);
-        const section = sectionId ? this.sectionById.get(sectionId) : null;
-        const sectionNameInput = (this.elements.existingSectionName?.value || '').trim();
-        const finalSectionNumber = sectionNumberInput ?? section?.position ?? null;
-        const resolvedSectionName = this.resolveSectionName(sectionId);
-        const finalSectionName = sectionNameInput || resolvedSectionName || null;
+        const form = this.existingForms[0];
 
-        this.items.push({
+        if (form?.filter) {
+            form.filter.focus();
+        } else if (form?.select) {
+            form.select.focus();
+        }
+    }
+
+    handleOpenManual() {
+        if (this.displayMode === 'modal') {
+            this.openModal('builder-manual');
+            return;
+        }
+
+        const form = this.manualForms[0];
+
+        if (form?.name) {
+            form.name.focus();
+        }
+    }
+
+    filterExistingOptions(form) {
+        this.applyExistingFilters(form);
+    }
+
+    applyExistingFilters(form) {
+        const select = form.select;
+
+        if (! select) {
+            return;
+        }
+
+        const query = form.filter?.value?.trim().toLowerCase() ?? '';
+        const letter = form.letter?.value?.trim().toLowerCase() ?? '';
+
+        Array.from(select.options).forEach((option, index) => {
+            if (index === 0) {
+                option.hidden = false;
+                return;
+            }
+
+            const text = option.textContent?.toLowerCase() ?? '';
+            const matchesQuery = query === '' || text.includes(query);
+            const matchesLetter = letter === '' || text.startsWith(letter);
+            option.hidden = ! (matchesQuery && matchesLetter);
+        });
+    }
+
+    handleExistingSelection(form) {
+        if (! form.select) {
+            return;
+        }
+
+        const productId = this.parseNullableInt(form.select.value);
+        const product = productId ? this.productById.get(productId) : null;
+
+        if (! product) {
+            return;
+        }
+
+        const quantity = form.quantity ? Number.parseFloat(form.quantity.value || '1') || 1 : 1;
+        const notes = form.notes?.value?.trim() || null;
+
+        const supermarketId = this.resolveDefaultSupermarketId(product);
+        const inventoryEntry = this.resolveInventoryEntry(product, supermarketId);
+
+        const item = {
             type: 'existing',
             product_id: product.id,
             product_name: product.name,
+            name: product.name,
+            brand: product.brand ?? null,
+            description: product.description ?? null,
+            unit: product.unit ?? '',
+            product_category_id: product.product_category_id ?? product.category_id ?? null,
+            package_size: product.package_size ?? null,
             quantity,
-            quantity_unit: unit || product.unit || null,
-            estimated_price: estimatedPrice,
+            quantity_unit: product.unit ?? '',
+            estimated_price: this.parsePrice(product.average_price) ?? null,
             supermarket_id: supermarketId,
             supermarket_name: this.resolveSupermarketName(supermarketId),
-            section_id: sectionId,
-            section_number: finalSectionNumber,
-            section_name: finalSectionName,
-            notes: null,
-        });
+            section_id: inventoryEntry?.section_id ?? null,
+            section_name: inventoryEntry?.section_name ?? null,
+            section_number: inventoryEntry?.section_position ?? null,
+            notes,
+        };
 
-        this.resetExistingInputs();
+        this.items.push(item);
         this.render();
+
+        if (form.select) {
+            form.select.value = '';
+        }
+
+        if (form.notes) {
+            form.notes.value = '';
+        }
+
+        if (form.quantity) {
+            form.quantity.value = '1';
+        }
     }
 
-    addManualItem() {
-        const name = (this.elements.manualName?.value || '').trim();
-        const unit = (this.elements.manualUnit?.value || '').trim();
+    resolveDefaultSupermarketId(product) {
+        if (this.defaultSupermarketId) {
+            return this.defaultSupermarketId;
+        }
+
+        if (Array.isArray(product.inventory) && product.inventory.length > 0) {
+            return product.inventory[0].supermarket_id ?? null;
+        }
+
+        return null;
+    }
+
+    resolveInventoryEntry(product, supermarketId) {
+        return this.getProductInventoryEntry(product?.id ?? null, supermarketId);
+    }
+
+    getProductInventoryEntry(productId, supermarketId) {
+        if (! productId) {
+            return null;
+        }
+
+        const product = this.productById.get(productId);
+
+        if (! product || ! Array.isArray(product.inventory)) {
+            return null;
+        }
+
+        if (supermarketId) {
+            const match = product.inventory.find((item) => item.supermarket_id === supermarketId);
+
+            if (match) {
+                return match;
+            }
+        }
+
+        return product.inventory[0] ?? null;
+    }
+
+    populateManualSections(form, selectedSectionId = null) {
+        if (! form.section) {
+            return;
+        }
+
+        const selectedSupermarket = this.parseNullableInt(form.supermarket?.value);
+        const targetSupermarket = selectedSupermarket ?? this.defaultSupermarketId;
+        const sections = targetSupermarket ? this.sectionsBySupermarket.get(targetSupermarket) ?? [] : [];
+
+        form.section.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Selecciona un pasillo';
+        form.section.appendChild(placeholder);
+
+        sections.forEach((section) => {
+            const option = document.createElement('option');
+            option.value = section.id;
+            option.textContent = this.formatSectionOption(section);
+
+            if (selectedSectionId && selectedSectionId === section.id) {
+                option.selected = true;
+            }
+
+            form.section.appendChild(option);
+        });
+    }
+
+    formatSectionOption(section) {
+        if (section.position !== null && section.position !== undefined) {
+            return section.name
+                ? `Pasillo ${section.position} · ${section.name}`
+                : `Pasillo ${section.position}`;
+        }
+
+        return section.name ?? 'Sin pasillo';
+    }
+
+    addManualItem(form) {
+        if (! form.name || ! form.unit) {
+            return;
+        }
+
+        const name = form.name.value.trim();
+        const unit = form.unit.value.trim();
 
         if (! name || ! unit) {
             alert('Los productos manuales necesitan un nombre y una unidad de medida.');
             return;
         }
 
-        const quantity = Number.parseFloat(this.elements.manualQuantity?.value ?? '1') || 1;
-        const estimatedPrice = this.parsePrice(this.elements.manualPrice?.value);
-        const supermarketId = this.parseNullableInt(this.elements.manualSupermarket?.value);
-        const sectionNumber = this.parseNullableInt(this.elements.manualSectionNumber?.value);
-        const sectionName = (this.elements.manualSectionName?.value || '').trim();
-        const categoryId = this.parseNullableInt(this.elements.manualCategory?.value);
+        const quantity = form.quantity ? Number.parseFloat(form.quantity.value || '1') || 1 : 1;
+        const price = form.price ? this.parsePrice(form.price.value) : null;
+        const supermarketId = this.parseNullableInt(form.supermarket?.value) ?? this.defaultSupermarketId;
+        const sectionId = this.parseNullableInt(form.section?.value);
+        const notes = form.notes?.value?.trim() || null;
 
-        this.items.push({
+        const item = {
             type: 'manual',
             name,
+            product_name: name,
             unit,
-            brand: (this.elements.manualBrand?.value || '').trim() || null,
-            package_size: null,
-            category_id: categoryId,
+            brand: form.brand?.value?.trim() || null,
             quantity,
             quantity_unit: unit,
-            estimated_price: estimatedPrice,
+            estimated_price: price,
             supermarket_id: supermarketId,
             supermarket_name: this.resolveSupermarketName(supermarketId),
-            section_id: null,
-            section_number: sectionNumber,
-            section_name: sectionName || null,
-            notes: (this.elements.manualNotes?.value || '').trim() || null,
+            section_id: sectionId,
+            section_name: this.resolveSectionName(sectionId),
+            section_number: this.sectionById.get(sectionId)?.position ?? null,
+            notes,
+        };
+
+        this.items.push(item);
+        this.render();
+        this.resetManualForm(form);
+    }
+
+    resetManualForm(form) {
+        form.name && (form.name.value = '');
+        form.unit && (form.unit.value = '');
+        form.brand && (form.brand.value = '');
+        form.quantity && (form.quantity.value = '1');
+        form.price && (form.price.value = '');
+        form.section && (form.section.value = '');
+        form.notes && (form.notes.value = '');
+
+        if (form.supermarket) {
+            form.supermarket.value = '';
+        }
+
+        this.populateManualSections(form);
+    }
+
+    openEditModal(index) {
+        const item = this.items[index];
+        const modal = this.modals.get('builder-edit');
+        const container = modal?.querySelector('[data-edit-form-container]');
+
+        if (! item || ! modal || ! container) {
+            return;
+        }
+
+        container.innerHTML = '';
+
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = `
+            <div class="grid gap-4 md:grid-cols-2">
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Nombre</label>
+                    <input type="text" data-edit-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" ${item.type === 'existing' ? 'readonly' : ''} value="${this.escapeHtmlAttribute(item.product_name ?? item.name ?? '')}">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Cantidad</label>
+                    <input type="number" step="0.01" min="0.01" data-edit-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" value="${item.quantity}">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Unidad</label>
+                    <input type="text" data-edit-unit class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" value="${this.escapeHtmlAttribute(item.quantity_unit ?? '')}">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Marca</label>
+                    <input type="text" data-edit-brand class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" value="${this.escapeHtmlAttribute(item.brand ?? '')}">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Precio estimado (unidad)</label>
+                    <input type="number" step="0.01" min="0" data-edit-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" value="${item.estimated_price ?? ''}">
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Descripción</label>
+                    <textarea rows="3" data-edit-description class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">${this.escapeHtml(item.description ?? '')}</textarea>
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Establecimiento</label>
+                    <select data-edit-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"></select>
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Pasillo / sección</label>
+                    <select data-edit-section class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"></select>
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Notas</label>
+                    <textarea rows="2" data-edit-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">${this.escapeHtml(item.notes ?? '')}</textarea>
+                </div>
+            </div>
+            <div class="flex items-center justify-end gap-3">
+                <button type="button" data-close-modal class="px-4 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Cancelar</button>
+                <button type="button" data-action="save-edit" class="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white shadow hover:bg-indigo-500">Guardar cambios</button>
+            </div>
+        `;
+
+        container.appendChild(wrapper);
+
+        const nameInput = container.querySelector('[data-edit-name]');
+        const quantityInput = container.querySelector('[data-edit-quantity]');
+        const unitInput = container.querySelector('[data-edit-unit]');
+        const brandInput = container.querySelector('[data-edit-brand]');
+        const priceInput = container.querySelector('[data-edit-price]');
+        const supermarketSelect = container.querySelector('[data-edit-supermarket]');
+        const sectionSelect = container.querySelector('[data-edit-section]');
+        const notesInput = container.querySelector('[data-edit-notes]');
+        const descriptionInput = container.querySelector('[data-edit-description]');
+        const saveButton = container.querySelector('[data-action="save-edit"]');
+
+        const initialSupermarketId = item.supermarket_id ?? this.defaultSupermarketId ?? null;
+        this.populateSupermarketOptions(supermarketSelect, initialSupermarketId);
+
+        if (supermarketSelect && initialSupermarketId && ! supermarketSelect.value) {
+            supermarketSelect.value = String(initialSupermarketId);
+        }
+
+        const effectiveSupermarketId = this.parseNullableInt(supermarketSelect?.value) ?? null;
+        const defaultEntry = this.getProductInventoryEntry(item.product_id, effectiveSupermarketId);
+        const initialSectionId = item.section_id ?? defaultEntry?.section_id ?? null;
+
+        this.populateEditSections(sectionSelect, effectiveSupermarketId, initialSectionId);
+
+        if (initialSectionId && sectionSelect && ! sectionSelect.value) {
+            sectionSelect.value = String(initialSectionId);
+        }
+
+        if (! item.supermarket_id && effectiveSupermarketId) {
+            item.supermarket_id = effectiveSupermarketId;
+            item.supermarket_name = this.resolveSupermarketName(effectiveSupermarketId);
+        }
+
+        supermarketSelect?.addEventListener('change', () => {
+            const targetSupermarket = this.parseNullableInt(supermarketSelect.value);
+            const entry = this.getProductInventoryEntry(item.product_id, targetSupermarket);
+            this.populateEditSections(sectionSelect, targetSupermarket, entry?.section_id ?? null);
         });
 
-        this.resetManualInputs();
-        this.render();
+        saveButton?.addEventListener('click', () => {
+            const quantity = Number.parseFloat(quantityInput?.value || '1') || 1;
+            const unit = unitInput?.value?.trim() || item.quantity_unit || '';
+            const brand = brandInput?.value?.trim() || null;
+            const price = this.parsePrice(priceInput?.value ?? null);
+            const supermarketId = this.parseNullableInt(supermarketSelect?.value) ?? null;
+            const sectionId = this.parseNullableInt(sectionSelect?.value) ?? null;
+            const notes = notesInput?.value?.trim() || null;
+            const description = descriptionInput?.value?.trim() || null;
+
+            if (item.type === 'manual' && nameInput) {
+                item.name = nameInput.value.trim();
+                item.product_name = item.name;
+            }
+
+            item.quantity = quantity;
+            item.quantity_unit = unit;
+            item.brand = brand;
+            item.estimated_price = price;
+            item.supermarket_id = supermarketId;
+            item.supermarket_name = this.resolveSupermarketName(supermarketId);
+            item.section_id = sectionId;
+            item.section_name = this.resolveSectionName(sectionId);
+            item.section_number = this.sectionById.get(sectionId)?.position ?? null;
+            item.notes = notes;
+            item.description = description;
+
+            this.render();
+            this.updateProductRecord(item);
+            this.closeModal(modal);
+        });
+
+        this.openModal('builder-edit');
+    }
+
+    populateSupermarketOptions(select, selectedId) {
+        if (! select) {
+            return;
+        }
+
+        select.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Usar predeterminado';
+        select.appendChild(placeholder);
+
+        this.supermarkets.forEach((market) => {
+            const option = document.createElement('option');
+            option.value = market.id;
+            option.textContent = market.name;
+
+            if (selectedId && selectedId === market.id) {
+                option.selected = true;
+            }
+
+            select.appendChild(option);
+        });
+    }
+
+    populateEditSections(select, supermarketId, selectedSectionId) {
+        if (! select) {
+            return;
+        }
+
+        const sections = supermarketId ? this.sectionsBySupermarket.get(supermarketId) ?? [] : [];
+
+        select.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Sin pasillo';
+        select.appendChild(placeholder);
+
+        sections.forEach((section) => {
+            const option = document.createElement('option');
+            option.value = section.id;
+            option.textContent = this.formatSectionOption(section);
+
+            if (selectedSectionId && selectedSectionId === section.id) {
+                option.selected = true;
+            }
+
+            select.appendChild(option);
+        });
+    }
+
+    openModal(id) {
+        const modal = this.modals.get(id);
+
+        if (modal) {
+            modal.classList.remove('hidden');
+        }
+    }
+
+    closeModal(modal) {
+        modal.classList.add('hidden');
     }
 
     parseNullableInt(value) {
@@ -216,7 +1091,7 @@ class ListBuilder {
     }
 
     parsePrice(value) {
-        if (! value) {
+        if (value === undefined || value === null || value === '') {
             return null;
         }
 
@@ -235,140 +1110,218 @@ class ListBuilder {
 
     resolveSectionName(id) {
         if (! id) {
-            return '';
+            return null;
         }
 
-        return this.sectionById.get(id)?.name ?? '';
+        return this.sectionById.get(id)?.name ?? null;
     }
 
-    resetExistingInputs() {
-        if (this.elements.existingProduct) {
-            this.elements.existingProduct.value = '';
+    updateProductRecord(item) {
+        if (item.type !== 'existing' || ! item.product_id || ! item.product_category_id || ! window.axios) {
+            return;
         }
 
-        if (this.elements.existingQuantity) {
-            this.elements.existingQuantity.value = '1';
+        const payload = {
+            name: item.product_name ?? item.name ?? '',
+            product_category_id: item.product_category_id,
+            brand: item.brand || null,
+            unit: item.quantity_unit || null,
+            package_size: item.package_size || null,
+            average_price: item.estimated_price ?? null,
+            description: item.description || null,
+        };
+
+        window.axios
+            .patch(`/products/${item.product_id}`, payload)
+            .then((response) => {
+                if (response?.data?.product) {
+                    this.mergeProductData(response.data.product);
+                } else {
+                    this.mergeProductFromItem(item);
+                }
+            })
+            .catch((error) => {
+                console.warn('No se pudo sincronizar el producto', error);
+                this.mergeProductFromItem(item);
+            });
+    }
+
+    mergeProductData(data) {
+        if (! data || data.id === undefined || data.id === null) {
+            return;
         }
 
-        if (this.elements.existingUnit) {
-            this.elements.existingUnit.value = '';
+        const product = this.productById.get(data.id);
+
+        if (! product) {
+            this.productById.set(data.id, {
+                ...data,
+                average_price: data.average_price !== null && data.average_price !== undefined
+                    ? Number.parseFloat(data.average_price)
+                    : null,
+                inventory: [],
+            });
+
+            return;
         }
 
-        if (this.elements.existingPrice) {
-            this.elements.existingPrice.value = '';
+        if (data.name !== undefined) {
+            product.name = data.name;
         }
 
-        if (this.elements.existingSupermarket) {
-            this.elements.existingSupermarket.value = '';
+        if (data.brand !== undefined) {
+            product.brand = data.brand;
         }
 
-        if (this.elements.existingSection) {
-            this.elements.existingSection.value = '';
+        if (data.unit !== undefined) {
+            product.unit = data.unit;
         }
 
-        if (this.elements.existingSectionNumber) {
-            this.elements.existingSectionNumber.value = '';
+        if (data.package_size !== undefined) {
+            product.package_size = data.package_size;
         }
 
-        if (this.elements.existingSectionName) {
-            this.elements.existingSectionName.value = '';
+        if (data.description !== undefined) {
+            product.description = data.description;
+        }
+
+        if (data.average_price !== undefined) {
+            product.average_price = data.average_price !== null
+                ? Number.parseFloat(data.average_price)
+                : null;
+        }
+
+        if (data.product_category_id !== undefined) {
+            product.product_category_id = data.product_category_id;
+            product.category_id = data.product_category_id;
         }
     }
 
-    resetManualInputs() {
-        if (this.elements.manualName) {
-            this.elements.manualName.value = '';
+    mergeProductFromItem(item) {
+        if (! item.product_id) {
+            return;
         }
 
-        if (this.elements.manualUnit) {
-            this.elements.manualUnit.value = '';
-        }
-
-        if (this.elements.manualBrand) {
-            this.elements.manualBrand.value = '';
-        }
-
-        if (this.elements.manualCategory) {
-            this.elements.manualCategory.value = '';
-        }
-
-        if (this.elements.manualQuantity) {
-            this.elements.manualQuantity.value = '1';
-        }
-
-        if (this.elements.manualPrice) {
-            this.elements.manualPrice.value = '';
-        }
-
-        if (this.elements.manualSupermarket) {
-            this.elements.manualSupermarket.value = '';
-        }
-
-        if (this.elements.manualSectionNumber) {
-            this.elements.manualSectionNumber.value = '';
-        }
-
-        if (this.elements.manualSectionName) {
-            this.elements.manualSectionName.value = '';
-        }
-
-        if (this.elements.manualNotes) {
-            this.elements.manualNotes.value = '';
-        }
+        this.mergeProductData({
+            id: item.product_id,
+            name: item.product_name ?? item.name ?? null,
+            brand: item.brand ?? null,
+            unit: item.quantity_unit ?? null,
+            package_size: item.package_size ?? null,
+            average_price: item.estimated_price ?? null,
+            description: item.description ?? null,
+            product_category_id: item.product_category_id ?? null,
+        });
     }
 
     render() {
         this.syncInput();
 
-        this.itemsTable.innerHTML = '';
-
-        if (this.items.length === 0) {
-            const row = document.createElement('tr');
-            row.className = 'empty-placeholder';
-            row.innerHTML = '<td colspan="6" class="px-4 py-6 text-center text-sm text-slate-500">Aún no agregaste productos. Usa el catálogo o crea uno manual.</td>';
-            this.itemsTable.appendChild(row);
+        if (! this.queueContainer) {
             return;
         }
 
+        Array.from(this.queueContainer.querySelectorAll('[data-rendered-item]')).forEach((element) => {
+            element.remove();
+        });
+
+        if (this.items.length === 0) {
+            this.emptyPlaceholder?.classList.remove('hidden');
+            return;
+        }
+
+        this.emptyPlaceholder?.classList.add('hidden');
+
         this.items.forEach((item, index) => {
-            const row = document.createElement('tr');
-            const sectionLabel = this.formatSectionLabel(item.section_number, item.section_name);
-            row.innerHTML = `
-                <td class="px-4 py-2">
-                    <p class="font-medium text-slate-800">${this.escapeHtml(item.product_name ?? item.name)}</p>
-                    <p class="text-xs text-slate-500">${item.type === 'manual' ? 'Creado manualmente' : 'Catálogo'}</p>
-                </td>
-                <td class="px-4 py-2">${item.quantity} ${this.escapeHtml(item.quantity_unit ?? '')}</td>
-                <td class="px-4 py-2 text-sm text-slate-600">${this.escapeHtml(item.supermarket_name ?? 'Por definir')}</td>
-                <td class="px-4 py-2 text-sm text-slate-600">${sectionLabel}</td>
-                <td class="px-4 py-2 text-sm text-slate-700">${this.formatPrice(item.quantity, item.estimated_price)}</td>
-                <td class="px-4 py-2 text-right">
-                    <button type="button" data-action="remove-item" data-index="${index}" class="text-sm text-rose-600 hover:underline">Eliminar</button>
-                </td>
-            `;
-            this.itemsTable.appendChild(row);
+            const element = this.createQueueItem(item, index);
+            this.queueContainer.appendChild(element);
         });
     }
 
-    formatSectionLabel(sectionNumber, sectionName) {
-        const hasNumber = sectionNumber !== null && sectionNumber !== undefined;
-        const safeName = sectionName ? this.escapeHtml(sectionName) : '';
+    createQueueItem(item, index) {
+        const template = this.itemTemplate?.content?.firstElementChild;
+        const element = template ? template.cloneNode(true) : document.createElement('article');
 
-        if (hasNumber) {
-            return safeName ? `Pasillo ${sectionNumber} · ${safeName}` : `Pasillo ${sectionNumber}`;
+        element.dataset.renderedItem = 'true';
+        element.dataset.index = String(index);
+
+        const nameNode = element.querySelector('[data-item-name]');
+        const metaNode = element.querySelector('[data-item-meta]');
+        const typeNode = element.querySelector('[data-item-type]');
+        const descriptionNode = element.querySelector('[data-item-description]');
+        const notesNode = element.querySelector('[data-item-notes]');
+        const editButton = element.querySelector('[data-action="edit-item"]');
+        const removeButton = element.querySelector('[data-action="remove-item"]');
+
+        if (nameNode) {
+            nameNode.textContent = item.product_name ?? item.name ?? 'Producto';
         }
 
-        return safeName || 'Sin pasillo';
+        if (metaNode) {
+            metaNode.textContent = this.formatMeta(item);
+        }
+
+        if (typeNode) {
+            typeNode.textContent = item.type === 'manual' ? 'Manual' : 'Catálogo';
+        }
+
+        if (descriptionNode) {
+            descriptionNode.textContent = this.formatDescription(item);
+        }
+
+        if (notesNode) {
+            if (item.notes) {
+                notesNode.textContent = `Notas: ${item.notes}`;
+                notesNode.classList.remove('hidden');
+            } else {
+                notesNode.textContent = '';
+                notesNode.classList.add('hidden');
+            }
+        }
+
+        if (editButton) {
+            editButton.dataset.index = String(index);
+        }
+
+        if (removeButton) {
+            removeButton.dataset.index = String(index);
+        }
+
+        return element;
     }
 
-    formatPrice(quantity, estimatedPrice) {
-        if (estimatedPrice === null || estimatedPrice === undefined) {
-            return '—';
+    formatMeta(item) {
+        const quantityLabel = `${item.quantity} ${item.quantity_unit ?? ''}`.trim();
+        const priceLabel = item.estimated_price !== null && item.estimated_price !== undefined
+            ? `· Estimado $${(item.estimated_price * item.quantity).toFixed(2)}`
+            : '';
+        const brandLabel = item.brand ? `· ${item.brand}` : '';
+
+        return [quantityLabel, brandLabel, priceLabel].filter(Boolean).join(' ');
+    }
+
+    formatDescription(item) {
+        const description = item.description ?? 'Sin descripción';
+        const location = this.formatLocation(item);
+
+        return `Descripción: ${description}. Ubicación: ${location}`;
+    }
+
+    formatLocation(item) {
+        const supermarket = item.supermarket_name ?? 'Por definir';
+        const sectionParts = [];
+
+        if (item.section_number !== null && item.section_number !== undefined) {
+            sectionParts.push(`Pasillo ${item.section_number}`);
         }
 
-        const total = (estimatedPrice || 0) * (quantity || 1);
+        if (item.section_name) {
+            sectionParts.push(item.section_name);
+        }
 
-        return `$${total.toFixed(2)}`;
+        const sectionLabel = sectionParts.length > 0 ? sectionParts.join(' · ') : 'Sin pasillo';
+
+        return `${supermarket} · ${sectionLabel}`;
     }
 
     syncInput() {
@@ -387,6 +1340,10 @@ class ListBuilder {
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
+    }
+
+    escapeHtmlAttribute(value) {
+        return this.escapeHtml(value ?? '').replace(/"/g, '&quot;');
     }
 }
 
@@ -544,6 +1501,10 @@ class SectionBuilder {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-product-catalog]').forEach((element) => {
+        new ProductCatalog(element);
+    });
+
     document.querySelectorAll('[data-list-builder]').forEach((element) => {
         new ListBuilder(element);
     });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -507,7 +507,6 @@ class ListBuilder {
             quantity: container.querySelector('[data-existing-quantity]'),
             notes: container.querySelector('[data-existing-notes]'),
             filter: container.querySelector('[data-existing-filter]'),
-            letter: container.querySelector('[data-existing-letter]'),
         }));
     }
 
@@ -592,17 +591,6 @@ class ListBuilder {
         this.existingForms.forEach((form) => {
             form.select?.addEventListener('change', () => this.handleExistingSelection(form));
             form.filter?.addEventListener('input', () => this.filterExistingOptions(form));
-            form.letter?.addEventListener('change', () => {
-                this.applyExistingFilters(form);
-
-                if (form.select && form.select.value) {
-                    const selectedOption = form.select.selectedOptions[0];
-
-                    if (selectedOption?.hidden) {
-                        form.select.value = '';
-                    }
-                }
-            });
 
             this.applyExistingFilters(form);
         });
@@ -679,7 +667,6 @@ class ListBuilder {
         }
 
         const query = form.filter?.value?.trim().toLowerCase() ?? '';
-        const letter = form.letter?.value?.trim().toLowerCase() ?? '';
 
         Array.from(select.options).forEach((option, index) => {
             if (index === 0) {
@@ -689,8 +676,7 @@ class ListBuilder {
 
             const text = option.textContent?.toLowerCase() ?? '';
             const matchesQuery = query === '' || text.includes(query);
-            const matchesLetter = letter === '' || text.startsWith(letter);
-            option.hidden = ! (matchesQuery && matchesLetter);
+            option.hidden = ! matchesQuery;
         });
     }
 

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,3 +2,9 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+const csrfToken = document.head.querySelector('meta[name="csrf-token"]');
+
+if (csrfToken) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken.content;
+}

--- a/resources/views/components/product-modals/add-to-list.blade.php
+++ b/resources/views/components/product-modals/add-to-list.blade.php
@@ -1,0 +1,90 @@
+@props(['activeLists', 'hasActiveLists'])
+
+@php
+    $actionTemplate = route('shopping-lists.items.store', ['shopping_list' => '__LIST__']);
+@endphp
+
+<div data-modal="product-add" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
+    <div class="bg-white rounded-2xl shadow-xl max-w-2xl w-full overflow-hidden">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+            <div>
+                <h2 class="text-lg font-semibold text-slate-800">Agregar producto a lista activa</h2>
+                <p class="text-xs text-slate-500">Elige una lista disponible y confirma los detalles antes de enviarlo.</p>
+            </div>
+            <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+        </div>
+
+        <form
+            method="POST"
+            data-product-add-form
+            data-action-template="{{ $actionTemplate }}"
+            class="px-6 py-6 space-y-6"
+        >
+            @csrf
+            <input type="hidden" name="items" value="[]" data-add-items>
+
+            <div data-add-body class="space-y-5 {{ $hasActiveLists ? '' : 'hidden' }}">
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Selecciona lista activa</label>
+                    <select data-add-list class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <option value="">-- Selecciona una lista --</option>
+                        @foreach($activeLists as $list)
+                            <option value="{{ $list->id }}">
+                                {{ $list->name }}
+                                @if($list->supermarket)
+                                    · {{ $list->supermarket->name }}
+                                @endif
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="border border-slate-200 rounded-xl bg-slate-50 p-4">
+                    <h3 class="text-sm font-semibold text-slate-700" data-add-product-name>Selecciona un producto</h3>
+                    <p class="text-xs text-slate-500" data-add-product-meta>Las especificaciones del producto aparecerán aquí.</p>
+                    <p class="text-sm text-slate-600 mt-3" data-add-product-description>Cuando abras el modal desde un producto se mostrarán sus detalles.</p>
+                </div>
+
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <label class="block text-xs font-semibold text-slate-500 mb-1">Cantidad</label>
+                        <div class="flex items-center gap-2">
+                            <input type="number" step="0.01" min="0.01" value="1" data-add-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <span class="inline-flex items-center px-3 py-2 text-xs font-medium text-slate-500 bg-slate-100 rounded-lg" data-add-unit>Unidad</span>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-semibold text-slate-500 mb-1">Precio estimado (unidad)</label>
+                        <input type="number" step="0.01" min="0" data-add-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="0.00">
+                    </div>
+                </div>
+
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Pasillo / sección</label>
+                    <select data-add-section class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <option value="">Sin pasillo asignado</option>
+                    </select>
+                    <p class="mt-1 text-xs text-slate-500" data-add-section-hint>Se usarán los pasillos del establecimiento principal de la lista seleccionada.</p>
+                </div>
+
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1">Notas para la lista</label>
+                    <textarea rows="2" data-add-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Observaciones o recordatorios"></textarea>
+                </div>
+
+                <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600" data-add-summary>
+                    Selecciona una lista activa para preparar el envío del producto.
+                </div>
+            </div>
+
+            <div data-add-empty class="text-sm text-slate-500 bg-slate-50 border border-slate-200 rounded-xl px-4 py-5 text-center {{ $hasActiveLists ? 'hidden' : '' }}">
+                No tienes listas activas disponibles en este momento. Activa una lista existente o crea una nueva desde el módulo de listas de compra.
+            </div>
+
+            <div class="flex items-center justify-end gap-3 pt-2 border-t border-slate-100">
+                <button type="button" data-close-modal class="px-4 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Cancelar</button>
+                <button type="submit" data-add-submit class="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white shadow hover:bg-indigo-500" @unless($hasActiveLists) disabled @endunless>Agregar a la lista</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/components/product-modals/create.blade.php
+++ b/resources/views/components/product-modals/create.blade.php
@@ -1,0 +1,57 @@
+@props(['categories'])
+
+<div data-modal="create-product" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
+    <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+            <div>
+                <h2 class="text-lg font-semibold text-slate-800">Agregar nuevo producto</h2>
+                <p class="text-xs text-slate-500">Completa la información y quedará disponible en el catálogo.</p>
+            </div>
+            <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+        </div>
+
+        <form method="POST" action="{{ route('products.store') }}" class="px-6 py-6 space-y-5">
+            @csrf
+            <div class="grid gap-4 md:grid-cols-2">
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-name">Nombre</label>
+                    <input id="create-name" name="name" type="text" required class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Arroz integral premium">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-category">Categoría</label>
+                    <select id="create-category" name="product_category_id" required class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <option value="">Selecciona una</option>
+                        @foreach($categories as $category)
+                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-brand">Marca</label>
+                    <input id="create-brand" name="brand" type="text" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Marca opcional">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-unit">Unidad</label>
+                    <input id="create-unit" name="unit" type="text" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="kg, paquete, pieza">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-package">Presentación</label>
+                    <input id="create-package" name="package_size" type="text" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Bolsa 1 kg">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-price">Precio promedio</label>
+                    <input id="create-price" name="average_price" type="number" step="0.01" min="0" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="120.00">
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-description">Descripción</label>
+                    <textarea id="create-description" name="description" rows="3" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Notas para reconocer el producto"></textarea>
+                </div>
+            </div>
+
+            <div class="flex items-center justify-end gap-3">
+                <button type="button" data-close-modal class="px-4 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Cancelar</button>
+                <button type="submit" class="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white shadow hover:bg-indigo-500">Guardar producto</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/components/product-modals/edit.blade.php
+++ b/resources/views/components/product-modals/edit.blade.php
@@ -1,4 +1,4 @@
-@props(['product', 'categories', 'filterLetter' => null])
+@props(['product', 'categories', 'searchTerm' => null])
 
 <div data-modal="edit-product-{{ $product->id }}" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
     <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
@@ -13,7 +13,7 @@
         <form method="POST" action="{{ route('products.update', $product) }}" class="px-6 py-6 space-y-5">
             @csrf
             @method('PUT')
-            <input type="hidden" name="letter" value="{{ $filterLetter }}">
+            <input type="hidden" name="search" value="{{ $searchTerm }}">
             <div class="grid gap-4 md:grid-cols-2">
                 <div class="md:col-span-2">
                     <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-name-{{ $product->id }}">Nombre</label>

--- a/resources/views/components/product-modals/edit.blade.php
+++ b/resources/views/components/product-modals/edit.blade.php
@@ -1,0 +1,58 @@
+@props(['product', 'categories', 'filterLetter' => null])
+
+<div data-modal="edit-product-{{ $product->id }}" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
+    <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+            <div>
+                <h2 class="text-lg font-semibold text-slate-800">Editar {{ $product->name }}</h2>
+                <p class="text-xs text-slate-500">Los cambios se guardarán directamente en el catálogo.</p>
+            </div>
+            <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+        </div>
+
+        <form method="POST" action="{{ route('products.update', $product) }}" class="px-6 py-6 space-y-5">
+            @csrf
+            @method('PUT')
+            <input type="hidden" name="letter" value="{{ $filterLetter }}">
+            <div class="grid gap-4 md:grid-cols-2">
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-name-{{ $product->id }}">Nombre</label>
+                    <input id="edit-name-{{ $product->id }}" name="name" type="text" value="{{ old('name', $product->name) }}" required class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-category-{{ $product->id }}">Categoría</label>
+                    <select id="edit-category-{{ $product->id }}" name="product_category_id" required class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        @foreach($categories as $category)
+                            <option value="{{ $category->id }}" @selected($product->product_category_id === $category->id)>{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-brand-{{ $product->id }}">Marca</label>
+                    <input id="edit-brand-{{ $product->id }}" name="brand" type="text" value="{{ old('brand', $product->brand) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-unit-{{ $product->id }}">Unidad</label>
+                    <input id="edit-unit-{{ $product->id }}" name="unit" type="text" value="{{ old('unit', $product->unit) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-package-{{ $product->id }}">Presentación</label>
+                    <input id="edit-package-{{ $product->id }}" name="package_size" type="text" value="{{ old('package_size', $product->package_size) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-price-{{ $product->id }}">Precio promedio</label>
+                    <input id="edit-price-{{ $product->id }}" name="average_price" type="number" step="0.01" min="0" value="{{ old('average_price', $product->average_price) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-description-{{ $product->id }}">Descripción</label>
+                    <textarea id="edit-description-{{ $product->id }}" name="description" rows="3" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">{{ old('description', $product->description) }}</textarea>
+                </div>
+            </div>
+
+            <div class="flex items-center justify-end gap-3">
+                <button type="button" data-close-modal class="px-4 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Cancelar</button>
+                <button type="submit" class="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white shadow hover:bg-indigo-500">Guardar cambios</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/components/product-modals/sections.blade.php
+++ b/resources/views/components/product-modals/sections.blade.php
@@ -1,0 +1,64 @@
+@props(['product', 'supermarkets', 'filterLetter' => null])
+
+<div data-modal="sections-product-{{ $product->id }}" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4 overflow-y-auto">
+    <div class="bg-white rounded-2xl shadow-xl max-w-3xl w-full overflow-hidden">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+            <div>
+                <h2 class="text-lg font-semibold text-slate-800">Pasillos por establecimiento</h2>
+                <p class="text-xs text-slate-500">Define dónde encontrar <strong>{{ $product->name }}</strong> en cada supermercado.</p>
+            </div>
+            <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+        </div>
+
+        <form method="POST" action="{{ route('products.sections.update', $product) }}" class="px-6 py-6 space-y-5">
+            @csrf
+            @method('PUT')
+            <input type="hidden" name="letter" value="{{ $filterLetter }}">
+
+            <div class="space-y-4">
+                @foreach($supermarkets as $supermarket)
+                    @php
+                        $inventory = $product->inventoryItems->firstWhere('supermarket_id', $supermarket->id);
+                        $currentSection = optional($inventory)->section;
+                    @endphp
+                    <div class="border border-slate-200 rounded-xl p-4">
+                        <div class="flex items-center justify-between mb-3">
+                            <div>
+                                <p class="font-semibold text-slate-700">{{ $supermarket->name }}</p>
+                                <p class="text-xs text-slate-500">{{ $supermarket->sections->count() }} pasillos disponibles</p>
+                            </div>
+                            <span class="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-600">{{ $currentSection ? 'Asignado' : 'Sin asignar' }}</span>
+                        </div>
+
+                        <div class="grid gap-4 md:grid-cols-2">
+                            <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1" for="section-select-{{ $product->id }}-{{ $supermarket->id }}">Pasillo / sección</label>
+                                <select id="section-select-{{ $product->id }}-{{ $supermarket->id }}" name="sections[{{ $loop->index }}][section_id]" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                                    <option value="">Sin asignar</option>
+                                    @foreach($supermarket->sections as $section)
+                                        <option value="{{ $section->id }}" @selected(optional($currentSection)->id === $section->id)>
+                                            Pasillo {{ $section->position }} · {{ $section->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1">Descripción actual</label>
+                                <div class="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-600 bg-slate-50">
+                                    {{ $currentSection ? 'Pasillo ' . $currentSection->position . ' · ' . $currentSection->name : 'Sin registro' }}
+                                </div>
+                            </div>
+                        </div>
+
+                        <input type="hidden" name="sections[{{ $loop->index }}][supermarket_id]" value="{{ $supermarket->id }}">
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="flex items-center justify-end gap-3">
+                <button type="button" data-close-modal class="px-4 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Cancelar</button>
+                <button type="submit" class="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white shadow hover:bg-indigo-500">Guardar pasillos</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/components/product-modals/sections.blade.php
+++ b/resources/views/components/product-modals/sections.blade.php
@@ -1,4 +1,4 @@
-@props(['product', 'supermarkets', 'filterLetter' => null])
+@props(['product', 'supermarkets', 'searchTerm' => null])
 
 <div data-modal="sections-product-{{ $product->id }}" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4 overflow-y-auto">
     <div class="bg-white rounded-2xl shadow-xl max-w-3xl w-full overflow-hidden">
@@ -13,7 +13,7 @@
         <form method="POST" action="{{ route('products.sections.update', $product) }}" class="px-6 py-6 space-y-5">
             @csrf
             @method('PUT')
-            <input type="hidden" name="letter" value="{{ $filterLetter }}">
+            <input type="hidden" name="search" value="{{ $searchTerm }}">
 
             <div class="space-y-4">
                 @foreach($supermarkets as $supermarket)

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -3,6 +3,23 @@
 @section('title', 'Dashboard')
 
 @section('content')
+    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-8">
+        <div>
+            <h1 class="text-2xl font-bold text-slate-800">Panel principal</h1>
+            <p class="text-sm text-slate-500">Consulta tus métricas recientes y gestiona rápidamente listas y productos.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+            <a href="{{ route('products.index') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-200 text-slate-700 rounded-lg shadow-sm hover:bg-slate-300">
+                <span class="text-lg">＋</span>
+                Agregar producto
+            </a>
+            <a href="{{ route('shopping-lists.create') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-500">
+                <span class="text-lg">＋</span>
+                Nueva lista
+            </a>
+        </div>
+    </div>
+
     <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
         <div class="bg-white rounded-xl shadow-sm p-5 border border-slate-100">
             <h2 class="text-sm text-slate-500">Listas pendientes</h2>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title', 'MarketGo')</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
@@ -18,6 +19,7 @@
                     <a href="{{ route('dashboard') }}" class="hover:text-indigo-600 {{ request()->routeIs('dashboard') ? 'text-indigo-600' : '' }}">Dashboard</a>
                     <a href="{{ route('shopping-lists.index') }}" class="hover:text-indigo-600 {{ request()->routeIs('shopping-lists.index') || request()->routeIs('shopping-lists.show') ? 'text-indigo-600' : '' }}">Listas de compra</a>
                     <a href="{{ route('shopping-lists.create') }}" class="hover:text-indigo-600 {{ request()->routeIs('shopping-lists.create') ? 'text-indigo-600' : '' }}">Crear lista</a>
+                    <a href="{{ route('products.index') }}" class="hover:text-indigo-600 {{ request()->routeIs('products.*') ? 'text-indigo-600' : '' }}">Productos</a>
                     <a href="{{ route('supermarkets.index') }}" class="hover:text-indigo-600 {{ request()->routeIs('supermarkets.*') ? 'text-indigo-600' : '' }}">Establecimientos</a>
                     @auth
                         @if(auth()->user()->is_admin)
@@ -61,5 +63,7 @@
             </div>
         </footer>
     </div>
+
+    @stack('modals')
 </body>
 </html>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -4,6 +4,8 @@
 
 @section('content')
     @php
+        use Illuminate\Support\Str;
+
         $hasActiveLists = $activeLists->isNotEmpty();
     @endphp
 
@@ -30,18 +32,30 @@
         </div>
 
         <form method="GET" action="{{ route('products.index') }}" class="mb-6">
-            <label class="block text-xs font-semibold text-slate-500 mb-2">Filtrar por inicial</label>
-            <select name="letter" class="w-40 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" onchange="this.form.submit()">
-                <option value="">Todas</option>
-                @foreach(range('A', 'Z') as $letterOption)
-                    <option value="{{ $letterOption }}" @selected($filterLetter === $letterOption)>{{ $letterOption }}</option>
-                @endforeach
-            </select>
+            <label class="block text-xs font-semibold text-slate-500 mb-2">Buscar producto por nombre</label>
+            <div class="flex items-center gap-2 max-w-xl">
+                <input
+                    type="text"
+                    name="search"
+                    value="{{ $searchTerm }}"
+                    placeholder="Escribe para filtrar"
+                    class="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    data-catalog-filter
+                >
+                <button type="submit" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg border border-slate-200 hover:bg-slate-200">
+                    Aplicar
+                </button>
+            </div>
         </form>
 
-        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3" data-catalog-grid>
             @forelse($products as $product)
-                <article class="bg-white border border-slate-200 rounded-xl shadow-sm p-5 flex flex-col gap-3" data-product-card data-product-id="{{ $product->id }}">
+                <article
+                    class="bg-white border border-slate-200 rounded-xl shadow-sm p-5 flex flex-col gap-3"
+                    data-product-card
+                    data-product-id="{{ $product->id }}"
+                    data-product-name="{{ Str::lower($product->name) }}"
+                >
                     <header class="flex items-start justify-between gap-3">
                         <div>
                             <h2 class="text-lg font-semibold text-slate-800">{{ $product->name }}</h2>
@@ -91,14 +105,13 @@
                         <form method="POST" action="{{ route('products.destroy', $product) }}" onsubmit="return confirm('¿Eliminar este producto?');" class="ml-auto">
                             @csrf
                             @method('DELETE')
-                            <input type="hidden" name="letter" value="{{ $filterLetter }}">
                             <button type="submit" class="px-3 py-2 text-sm rounded-lg border border-rose-200 text-rose-600 hover:bg-rose-50">Eliminar</button>
                         </form>
                     </footer>
                 </article>
 
-                <x-product-modals.edit :product="$product" :categories="$categories" :filter-letter="$filterLetter" />
-                <x-product-modals.sections :product="$product" :supermarkets="$supermarkets" :filter-letter="$filterLetter" />
+                <x-product-modals.edit :product="$product" :categories="$categories" :search-term="$searchTerm" />
+                <x-product-modals.sections :product="$product" :supermarkets="$supermarkets" :search-term="$searchTerm" />
             @empty
                 <div class="md:col-span-2 xl:col-span-3 bg-white border border-dashed border-slate-300 rounded-xl p-10 text-center">
                     <p class="text-slate-500">No hay productos que coincidan con el filtro seleccionado.</p>
@@ -113,9 +126,9 @@
 
 @push('modals')
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            document.querySelectorAll('[data-open-modal]').forEach((button) => {
-                button.addEventListener('click', () => {
+            document.addEventListener('DOMContentLoaded', () => {
+                document.querySelectorAll('[data-open-modal]').forEach((button) => {
+                    button.addEventListener('click', () => {
                     const modalId = button.dataset.openModal;
                     const modal = document.querySelector(`[data-modal="${modalId}"]`);
 
@@ -133,6 +146,22 @@
                         modal.classList.add('hidden');
                     }
                 });
+
+                const filterInput = document.querySelector('[data-catalog-filter]');
+                const grid = document.querySelector('[data-catalog-grid]');
+                const cards = grid ? Array.from(grid.querySelectorAll('[data-product-card]')) : [];
+
+                const applyFilter = () => {
+                    const query = filterInput?.value?.toLowerCase().trim() ?? '';
+
+                    cards.forEach((card) => {
+                        const name = card.dataset.productName ?? '';
+                        card.classList.toggle('hidden', query !== '' && ! name.includes(query));
+                    });
+                };
+
+                filterInput?.addEventListener('input', applyFilter);
+                applyFilter();
             });
         });
     </script>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,139 @@
+@extends('layouts.app')
+
+@section('title', 'Catálogo de productos')
+
+@section('content')
+    @php
+        $hasActiveLists = $activeLists->isNotEmpty();
+    @endphp
+
+    <div
+        data-product-catalog
+        data-products='@json($productDataset)'
+        data-lists='@json($activeListsDataset)'
+        data-sections='@json($sectionDataset)'
+    >
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-6">
+            <div>
+                <h1 class="text-2xl font-bold text-slate-800">Catálogo de productos</h1>
+                <p class="text-sm text-slate-500">Administra la información de tus productos y mantén actualizados sus pasillos por establecimiento.</p>
+                @unless($hasActiveLists)
+                    <p class="mt-2 text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">Crea o activa una lista para habilitar el envío directo desde aquí.</p>
+                @endunless
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+                <button type="button" data-open-modal="create-product" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-500">
+                    <span class="text-lg">＋</span>
+                    <span>Agregar producto</span>
+                </button>
+            </div>
+        </div>
+
+        <form method="GET" action="{{ route('products.index') }}" class="mb-6">
+            <label class="block text-xs font-semibold text-slate-500 mb-2">Filtrar por inicial</label>
+            <select name="letter" class="w-40 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" onchange="this.form.submit()">
+                <option value="">Todas</option>
+                @foreach(range('A', 'Z') as $letterOption)
+                    <option value="{{ $letterOption }}" @selected($filterLetter === $letterOption)>{{ $letterOption }}</option>
+                @endforeach
+            </select>
+        </form>
+
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            @forelse($products as $product)
+                <article class="bg-white border border-slate-200 rounded-xl shadow-sm p-5 flex flex-col gap-3" data-product-card data-product-id="{{ $product->id }}">
+                    <header class="flex items-start justify-between gap-3">
+                        <div>
+                            <h2 class="text-lg font-semibold text-slate-800">{{ $product->name }}</h2>
+                            <p class="text-xs text-slate-500">{{ $product->brand ?? 'Sin marca' }} · {{ optional($product->category)->name ?? 'Sin categoría' }}</p>
+                        </div>
+                        <span class="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-600">ID #{{ $product->id }}</span>
+                    </header>
+
+                    <dl class="grid grid-cols-2 gap-3 text-sm text-slate-600">
+                        <div>
+                            <dt class="font-medium text-slate-500 uppercase text-xs">Unidad</dt>
+                            <dd class="mt-1">{{ $product->unit ?? '—' }}</dd>
+                        </div>
+                        <div>
+                            <dt class="font-medium text-slate-500 uppercase text-xs">Presentación</dt>
+                            <dd class="mt-1">{{ $product->package_size ?? '—' }}</dd>
+                        </div>
+                        <div>
+                            <dt class="font-medium text-slate-500 uppercase text-xs">Precio promedio</dt>
+                            <dd class="mt-1">{{ $product->average_price ? '$' . number_format($product->average_price, 2) : '—' }}</dd>
+                        </div>
+                        <div>
+                            <dt class="font-medium text-slate-500 uppercase text-xs">Pasillos registrados</dt>
+                            <dd class="mt-1">{{ $product->inventoryItems->whereNotNull('supermarket_section_id')->count() }}</dd>
+                        </div>
+                    </dl>
+
+                    @if($product->description)
+                        <p class="text-sm text-slate-600 border-t border-slate-100 pt-3">{{ $product->description }}</p>
+                    @endif
+
+                    <footer class="flex flex-wrap items-center gap-2 pt-2 border-t border-slate-100 mt-auto">
+                        <button
+                            type="button"
+                            data-action="open-add"
+                            @class([
+                                'px-3 py-2 text-sm rounded-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-200/60',
+                                'border border-emerald-200 text-emerald-600 hover:bg-emerald-50' => $hasActiveLists,
+                                'border border-slate-200 text-slate-400 cursor-not-allowed opacity-60' => ! $hasActiveLists,
+                            ])
+                            @unless($hasActiveLists) disabled @endunless
+                        >
+                            Agregar a lista
+                        </button>
+                        <button type="button" data-open-modal="edit-product-{{ $product->id }}" class="px-3 py-2 text-sm rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">Editar</button>
+                        <button type="button" data-open-modal="sections-product-{{ $product->id }}" class="px-3 py-2 text-sm rounded-lg border border-indigo-200 text-indigo-600 hover:bg-indigo-50">Ver pasillos</button>
+                        <form method="POST" action="{{ route('products.destroy', $product) }}" onsubmit="return confirm('¿Eliminar este producto?');" class="ml-auto">
+                            @csrf
+                            @method('DELETE')
+                            <input type="hidden" name="letter" value="{{ $filterLetter }}">
+                            <button type="submit" class="px-3 py-2 text-sm rounded-lg border border-rose-200 text-rose-600 hover:bg-rose-50">Eliminar</button>
+                        </form>
+                    </footer>
+                </article>
+
+                <x-product-modals.edit :product="$product" :categories="$categories" :filter-letter="$filterLetter" />
+                <x-product-modals.sections :product="$product" :supermarkets="$supermarkets" :filter-letter="$filterLetter" />
+            @empty
+                <div class="md:col-span-2 xl:col-span-3 bg-white border border-dashed border-slate-300 rounded-xl p-10 text-center">
+                    <p class="text-slate-500">No hay productos que coincidan con el filtro seleccionado.</p>
+                </div>
+            @endforelse
+        </div>
+
+        <x-product-modals.create :categories="$categories" />
+        <x-product-modals.add-to-list :active-lists="$activeLists" :has-active-lists="$hasActiveLists" />
+    </div>
+@endsection
+
+@push('modals')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('[data-open-modal]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const modalId = button.dataset.openModal;
+                    const modal = document.querySelector(`[data-modal="${modalId}"]`);
+
+                    if (modal) {
+                        modal.classList.remove('hidden');
+                    }
+                });
+            });
+
+            document.querySelectorAll('[data-close-modal]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const modal = button.closest('[data-modal]');
+
+                    if (modal) {
+                        modal.classList.add('hidden');
+                    }
+                });
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/shopping-lists/create.blade.php
+++ b/resources/views/shopping-lists/create.blade.php
@@ -11,6 +11,20 @@
         <section class="bg-white rounded-xl shadow-sm border border-slate-100 p-6">
             <h2 class="text-lg font-semibold text-slate-800 mb-4">Detalles de la lista</h2>
             <div class="grid gap-5 md:grid-cols-2">
+                <div class="md:col-span-2">
+                    <label class="block text-sm font-medium text-slate-600 mb-1">Estado de la lista</label>
+                    <div class="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+                        <label class="flex items-center gap-2">
+                            <input type="radio" name="status" value="active" class="text-indigo-600" @checked(old('status', 'active') === 'active')>
+                            Activa
+                        </label>
+                        <label class="flex items-center gap-2">
+                            <input type="radio" name="status" value="draft" class="text-indigo-600" @checked(old('status') === 'draft')>
+                            Inactiva
+                        </label>
+                        <p class="text-xs text-slate-500">Puedes activar o pausar la lista en cualquier momento.</p>
+                    </div>
+                </div>
                 <div>
                     <label class="block text-sm font-medium text-slate-600 mb-1" for="name">Nombre</label>
                     <input type="text" id="name" name="name" value="{{ old('name') }}" required class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Compra semanal">
@@ -46,6 +60,8 @@
             'productDataset' => $productDataset,
             'supermarketDataset' => $supermarketDataset,
             'sectionDataset' => $sectionDataset,
+            'displayMode' => 'inline',
+            'defaultSupermarketId' => old('supermarket_id'),
         ])
 
         <div class="flex justify-end">

--- a/resources/views/shopping-lists/index.blade.php
+++ b/resources/views/shopping-lists/index.blade.php
@@ -12,10 +12,16 @@
             <h1 class="text-2xl font-bold text-slate-800">Tus listas de compra</h1>
             <p class="text-sm text-slate-500">Administra tus listas activas, borradores y compras anteriores.</p>
         </div>
-        <a href="{{ route('shopping-lists.create') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-500">
-            <span class="text-lg">＋</span>
-            Nueva lista
-        </a>
+        <div class="flex items-center gap-3">
+            <a href="{{ route('products.index') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-200 text-slate-700 rounded-lg shadow-sm hover:bg-slate-300">
+                <span class="text-lg">＋</span>
+                Agregar producto
+            </a>
+            <a href="{{ route('shopping-lists.create') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-500">
+                <span class="text-lg">＋</span>
+                Nueva lista
+            </a>
+        </div>
     </div>
 
     <div class="bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden">

--- a/resources/views/shopping-lists/partials/item-builder.blade.php
+++ b/resources/views/shopping-lists/partials/item-builder.blade.php
@@ -1,155 +1,273 @@
+@php
+    $displayMode = $displayMode ?? 'inline';
+    $isModalMode = $displayMode === 'modal';
+@endphp
+
 <input type="hidden" name="items" id="items-input" value="{{ old('items', '[]') }}">
 
 <section
     class="bg-white rounded-xl shadow-sm border border-slate-100 p-6"
     data-list-builder
+    data-display-mode="{{ $displayMode }}"
     data-products='@json($productDataset ?? [])'
     data-supermarkets='@json($supermarketDataset ?? [])'
     data-sections='@json($sectionDataset ?? [])'
+    data-default-supermarket="{{ $defaultSupermarketId ?? '' }}"
+    data-supermarket-field="#supermarket_id"
 >
-    <h2 class="text-lg font-semibold text-slate-800 mb-4">Selecciona tus productos</h2>
+    <header class="flex flex-col gap-2 mb-6 md:flex-row md:items-center md:justify-between">
+        <div>
+            <h2 class="text-lg font-semibold text-slate-800">Preparar productos</h2>
+            <p class="text-sm text-slate-500">Selecciona productos del catálogo o agrega nuevos manualmente. Todos aparecerán en la cola de preparación.</p>
+        </div>
+        <div class="flex items-center gap-2">
+            <button type="button" data-action="open-existing" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-indigo-200 text-indigo-600 hover:bg-indigo-50">
+                <span class="text-lg">＋</span>
+                Catálogo
+            </button>
+            <button type="button" data-action="open-manual" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-emerald-200 text-emerald-600 hover:bg-emerald-50">
+                <span class="text-lg">＋</span>
+                Manual
+            </button>
+        </div>
+    </header>
 
     @error('items')
         <p class="mb-4 text-sm text-rose-600">{{ $message }}</p>
     @enderror
 
-    <div class="grid gap-6 lg:grid-cols-2">
-        <div class="space-y-4">
-            <h3 class="text-sm font-semibold text-slate-700">Catálogo existente</h3>
-            <div class="grid gap-4 sm:grid-cols-2">
-                <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Producto del catálogo</label>
-                    <select data-existing-product class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="">-- Selecciona un producto --</option>
-                        @foreach($products as $product)
-                            <option value="{{ $product->id }}">{{ $product->name }} @if($product->brand)· {{ $product->brand }}@endif</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
-                    <input type="number" step="0.01" min="0.01" value="1" data-existing-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Unidad</label>
-                    <input type="text" data-existing-unit class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="pieza">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Precio estimado (por unidad)</label>
-                    <input type="number" step="0.01" min="0" data-existing-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="35.00">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
-                    <select data-existing-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="">Igual al de la lista</option>
-                        @foreach($supermarkets as $market)
-                            <option value="{{ $market->id }}">{{ $market->name }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo (número)</label>
-                    <input type="number" data-existing-section-number min="0" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="1">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo / sección</label>
-                    <select data-existing-section class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="">Selecciona sección</option>
-                        @foreach($supermarkets as $market)
-                            <optgroup label="{{ $market->name }}">
-                                @foreach($market->sections as $section)
-                                    <option value="{{ $section->id }}">Pasillo {{ $section->position }} · {{ $section->name }}</option>
+    <div class="space-y-4" data-items-queue>
+        <div data-empty-placeholder class="border border-dashed border-slate-300 rounded-lg p-6 text-center text-sm text-slate-500">
+            Aún no agregaste productos. Usa el catálogo o crea uno manual para comenzar tu cola.
+        </div>
+    </div>
+
+    @if(! $isModalMode)
+        <div class="grid gap-6 mt-8 lg:grid-cols-2" data-inline-forms>
+            <div class="border border-slate-200 rounded-xl p-5" data-existing-block>
+                <h3 class="text-sm font-semibold text-slate-700 mb-3">Catálogo existente</h3>
+                <div class="space-y-4">
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Filtrar por inicial</label>
+                            <select data-existing-letter class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                                <option value="">Todas</option>
+                                @foreach(range('A', 'Z') as $letterOption)
+                                    <option value="{{ $letterOption }}">{{ $letterOption }}</option>
                                 @endforeach
-                            </optgroup>
-                        @endforeach
-                    </select>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Buscar producto</label>
+                            <input type="text" data-existing-filter placeholder="Escribe para filtrar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>
+                        <select data-existing-product class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <option value="">-- Selecciona --</option>
+                            @foreach($products as $product)
+                                <option value="{{ $product->id }}">{{ $product->name }} @if($product->brand)· {{ $product->brand }}@endif</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
+                            <input type="number" step="0.01" min="0.01" value="1" data-existing-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Notas para la lista</label>
+                            <input type="text" data-existing-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Observaciones opcionales">
+                        </div>
+                    </div>
                 </div>
-                <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-slate-500 mb-1">¿No encuentras el pasillo? Escribe uno nuevo</label>
-                    <input type="text" data-existing-section-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Almacén">
-                </div>
+                <p class="mt-4 text-xs text-slate-500">Los productos se agregan automáticamente a la cola al seleccionarlos.</p>
             </div>
-            <button type="button" data-action="add-existing" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-500">Agregar a la lista</button>
-        </div>
 
-        <div class="space-y-4">
-            <h3 class="text-sm font-semibold text-slate-700">Agregar producto manual</h3>
-            <div class="grid gap-4 sm:grid-cols-2">
-                <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Nombre del producto *</label>
-                    <input type="text" data-manual-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Pasta artesanal">
+            <div class="border border-slate-200 rounded-xl p-5" data-manual-block>
+                <h3 class="text-sm font-semibold text-slate-700 mb-3">Agregar producto manual</h3>
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div class="sm:col-span-2">
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Nombre *</label>
+                        <input type="text" data-manual-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Producto especial">
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Unidad *</label>
+                        <input type="text" data-manual-unit class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="pieza, paquete">
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Marca</label>
+                        <input type="text" data-manual-brand class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Opcional">
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
+                        <input type="number" step="0.01" min="0.01" value="1" data-manual-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Precio estimado (unidad)</label>
+                        <input type="number" step="0.01" min="0" data-manual-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="45.00">
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
+                        <select data-manual-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                            <option value="">Igual al de la lista</option>
+                            @foreach($supermarkets as $market)
+                                <option value="{{ $market->id }}">{{ $market->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo / sección</label>
+                        <select data-manual-section class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                            <option value="">Selecciona un pasillo</option>
+                        </select>
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Notas para la lista</label>
+                        <textarea rows="2" data-manual-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Detalles adicionales"></textarea>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Unidad de medida *</label>
-                    <input type="text" data-manual-unit class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="paquete">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Marca</label>
-                    <input type="text" data-manual-brand class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Marca opcional">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Categoría</label>
-                    <select data-manual-category class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="">Selecciona categoría</option>
-                        @foreach($categories as $category)
-                            <option value="{{ $category->id }}">{{ $category->name }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
-                    <input type="number" step="0.01" min="0.01" value="1" data-manual-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Precio estimado (por unidad)</label>
-                    <input type="number" step="0.01" min="0" data-manual-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="45.00">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
-                    <select data-manual-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <option value="">Igual al de la lista</option>
-                        @foreach($supermarkets as $market)
-                            <option value="{{ $market->id }}">{{ $market->name }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo (número)</label>
-                    <input type="number" data-manual-section-number min="0" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="3">
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo / sección</label>
-                    <input type="text" data-manual-section-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Pasillo B">
-                </div>
-                <div class="sm:col-span-2">
-                    <label class="block text-xs font-medium text-slate-500 mb-1">Notas</label>
-                    <textarea rows="2" data-manual-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Detalles adicionales"></textarea>
-                </div>
+                <button type="button" data-action="add-manual" class="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg shadow hover:bg-emerald-500">Crear y agregar a la cola</button>
             </div>
-            <button type="button" data-action="add-manual" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg shadow hover:bg-emerald-500">Crear producto y agregar</button>
+        </div>
+    @endif
+
+    <template data-item-template>
+        <article class="border border-slate-200 rounded-xl p-4 bg-slate-50 flex flex-col gap-2">
+            <header class="flex items-start justify-between gap-2">
+                <div>
+                    <h3 class="font-semibold text-slate-800" data-item-name></h3>
+                    <p class="text-xs text-slate-500" data-item-meta></p>
+                </div>
+                <span class="text-xs px-2 py-1 rounded-full bg-slate-200 text-slate-600" data-item-type></span>
+            </header>
+            <p class="text-sm text-slate-600" data-item-description></p>
+            <div class="text-xs text-slate-500" data-item-notes></div>
+            <div class="flex items-center gap-3 pt-2 border-t border-slate-200 mt-2">
+                <button type="button" data-action="edit-item" class="text-sm text-indigo-600 hover:underline">Editar</button>
+                <button type="button" data-action="remove-item" class="text-sm text-rose-600 hover:underline">Eliminar</button>
+            </div>
+        </article>
+    </template>
+
+    <div data-modal="builder-edit" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
+        <div class="bg-white rounded-2xl shadow-xl max-w-2xl w-full overflow-hidden">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+                <div>
+                    <h3 class="text-lg font-semibold text-slate-800">Editar producto en cola</h3>
+                    <p class="text-xs text-slate-500">Ajusta la información antes de guardar en la lista.</p>
+                </div>
+                <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+            </div>
+            <div class="px-6 py-6 space-y-5" data-edit-form-container></div>
         </div>
     </div>
 
-    <div class="mt-8">
-        <h3 class="text-sm font-semibold text-slate-700 mb-3">Resumen de productos añadidos</h3>
-        <div class="overflow-hidden border border-slate-200 rounded-lg">
-            <table class="min-w-full divide-y divide-slate-200 text-sm">
-                <thead class="bg-slate-50">
-                    <tr>
-                        <th class="px-4 py-2 text-left">Producto</th>
-                        <th class="px-4 py-2 text-left">Cantidad</th>
-                        <th class="px-4 py-2 text-left">Establecimiento</th>
-                        <th class="px-4 py-2 text-left">Pasillo</th>
-                        <th class="px-4 py-2 text-left">Precio estimado</th>
-                        <th class="px-4 py-2 text-right">Acciones</th>
-                    </tr>
-                </thead>
-                <tbody data-items-table class="divide-y divide-slate-200 bg-white">
-                    <tr class="empty-placeholder">
-                        <td colspan="6" class="px-4 py-6 text-center text-sm text-slate-500">Aún no agregaste productos. Usa el catálogo o crea uno manual.</td>
-                    </tr>
-                </tbody>
-            </table>
+    @if($isModalMode)
+        <div data-modal="builder-existing" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
+            <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+                    <div>
+                        <h3 class="text-lg font-semibold text-slate-800">Agregar desde catálogo</h3>
+                        <p class="text-xs text-slate-500">Selecciona un producto y se añadirá a la cola.</p>
+                    </div>
+                    <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+                </div>
+                <div class="px-6 py-6 space-y-4" data-existing-block>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Filtrar por inicial</label>
+                            <select data-existing-letter class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                                <option value="">Todas</option>
+                                @foreach(range('A', 'Z') as $letterOption)
+                                    <option value="{{ $letterOption }}">{{ $letterOption }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Buscar producto</label>
+                            <input type="text" data-existing-filter placeholder="Escribe para filtrar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>
+                        <select data-existing-product class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <option value="">-- Selecciona --</option>
+                            @foreach($products as $product)
+                                <option value="{{ $product->id }}">{{ $product->name }} @if($product->brand)· {{ $product->brand }}@endif</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
+                            <input type="number" step="0.01" min="0.01" value="1" data-existing-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Notas para la lista</label>
+                            <input type="text" data-existing-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Observaciones opcionales">
+                        </div>
+                    </div>
+                    <p class="text-xs text-slate-500">Al seleccionar un producto se agregará automáticamente a la cola.</p>
+                </div>
+            </div>
         </div>
-    </div>
+
+        <div data-modal="builder-manual" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
+            <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+                    <div>
+                        <h3 class="text-lg font-semibold text-slate-800">Nuevo producto manual</h3>
+                        <p class="text-xs text-slate-500">Se creará en la base de datos y se agregará a la cola.</p>
+                    </div>
+                    <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+                </div>
+                <div class="px-6 py-6 space-y-4" data-manual-form-wrapper data-manual-block>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div class="sm:col-span-2">
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Nombre *</label>
+                            <input type="text" data-manual-name class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Producto especial">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Unidad *</label>
+                            <input type="text" data-manual-unit class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="pieza, paquete">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Marca</label>
+                            <input type="text" data-manual-brand class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Opcional">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
+                            <input type="number" step="0.01" min="0.01" value="1" data-manual-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Precio estimado (unidad)</label>
+                            <input type="number" step="0.01" min="0" data-manual-price class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="45.00">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
+                            <select data-manual-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                                <option value="">Igual al de la lista</option>
+                                @foreach($supermarkets as $market)
+                                    <option value="{{ $market->id }}">{{ $market->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Pasillo / sección</label>
+                            <select data-manual-section class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+                                <option value="">Selecciona un pasillo</option>
+                            </select>
+                        </div>
+                        <div class="sm:col-span-2">
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Notas para la lista</label>
+                            <textarea rows="2" data-manual-notes class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500" placeholder="Detalles adicionales"></textarea>
+                        </div>
+                    </div>
+                    <button type="button" data-action="add-manual" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg shadow hover:bg-emerald-500">Crear y agregar a la cola</button>
+                </div>
+            </div>
+        </div>
+    @endif
 </section>

--- a/resources/views/shopping-lists/partials/item-builder.blade.php
+++ b/resources/views/shopping-lists/partials/item-builder.blade.php
@@ -47,20 +47,9 @@
             <div class="border border-slate-200 rounded-xl p-5" data-existing-block>
                 <h3 class="text-sm font-semibold text-slate-700 mb-3">Catálogo existente</h3>
                 <div class="space-y-4">
-                    <div class="grid gap-3 sm:grid-cols-2">
-                        <div>
-                            <label class="block text-xs font-medium text-slate-500 mb-1">Filtrar por inicial</label>
-                            <select data-existing-letter class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                                <option value="">Todas</option>
-                                @foreach(range('A', 'Z') as $letterOption)
-                                    <option value="{{ $letterOption }}">{{ $letterOption }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div>
-                            <label class="block text-xs font-medium text-slate-500 mb-1">Buscar producto</label>
-                            <input type="text" data-existing-filter placeholder="Escribe para filtrar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y filtrar</label>
+                        <input type="text" data-existing-filter placeholder="Escribe para filtrar productos por nombre" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                     </div>
                     <div>
                         <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>
@@ -175,20 +164,9 @@
                     <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
                 </div>
                 <div class="px-6 py-6 space-y-4" data-existing-block>
-                    <div class="grid gap-3 sm:grid-cols-2">
-                        <div>
-                            <label class="block text-xs font-medium text-slate-500 mb-1">Filtrar por inicial</label>
-                            <select data-existing-letter class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                                <option value="">Todas</option>
-                                @foreach(range('A', 'Z') as $letterOption)
-                                    <option value="{{ $letterOption }}">{{ $letterOption }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div>
-                            <label class="block text-xs font-medium text-slate-500 mb-1">Buscar producto</label>
-                            <input type="text" data-existing-filter placeholder="Escribe para filtrar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        </div>
+                    <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y filtrar</label>
+                        <input type="text" data-existing-filter placeholder="Escribe para filtrar productos por nombre" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                     </div>
                     <div>
                         <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>

--- a/resources/views/shopping-lists/show.blade.php
+++ b/resources/views/shopping-lists/show.blade.php
@@ -15,6 +15,19 @@
         <div>
             <h1 class="text-2xl font-bold text-slate-800">{{ $shoppingList->name }}</h1>
             <p class="text-sm text-slate-500">{{ optional($shoppingList->supermarket)->name ?? 'Sin establecimiento principal' }}</p>
+            <div class="mt-3 flex items-center gap-3">
+                <span class="inline-flex items-center px-3 py-1 text-xs font-semibold rounded-full {{ $shoppingList->status === 'active' ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' }}">
+                    {{ $shoppingList->status === 'active' ? 'Lista activa' : 'Lista inactiva' }}
+                </span>
+                <form method="POST" action="{{ route('shopping-lists.update', $shoppingList) }}" class="inline-flex items-center gap-2">
+                    @csrf
+                    @method('PATCH')
+                    <input type="hidden" name="status" value="{{ $shoppingList->status === 'active' ? 'draft' : 'active' }}">
+                    <button type="submit" class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-100">
+                        {{ $shoppingList->status === 'active' ? 'Desactivar lista' : 'Activar lista' }}
+                    </button>
+                </form>
+            </div>
         </div>
         <a href="{{ route('shopping-lists.index') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200">← Volver a todas las listas</a>
     </div>
@@ -64,6 +77,8 @@
                 'productDataset' => $productDataset,
                 'supermarketDataset' => $supermarketDataset,
                 'sectionDataset' => $sectionDataset,
+                'displayMode' => 'modal',
+                'defaultSupermarketId' => $shoppingList->supermarket_id,
             ])
 
             <div class="flex justify-end">

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ShoppingListController;
 use App\Http\Controllers\ShoppingListItemStatusController;
 use App\Http\Controllers\SupermarketController;
@@ -25,8 +26,14 @@ Route::middleware('auth')->group(function (): void {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
     Route::resource('shopping-lists', ShoppingListController::class)->only(['index', 'create', 'store', 'show']);
+    Route::patch('shopping-lists/{shopping_list}', [ShoppingListController::class, 'update'])
+        ->name('shopping-lists.update');
     Route::post('shopping-lists/{shopping_list}/items', [ShoppingListController::class, 'addItems'])
         ->name('shopping-lists.items.store');
+
+    Route::resource('products', ProductController::class)->only(['index', 'store', 'update', 'destroy']);
+    Route::put('products/{product}/sections', [ProductController::class, 'updateSections'])
+        ->name('products.sections.update');
 
     Route::patch('shopping-lists/{shopping_list}/items/{shopping_list_item}/status', ShoppingListItemStatusController::class)
         ->name('shopping-lists.items.status');


### PR DESCRIPTION
## Summary
- add reusable product catalog modal to queue items into active shopping lists and expose supporting datasets
- refine shopping list builder UI with alphabetical filters, prefilled product metadata, and improved product syncing
- surface quick actions for creating lists and products from the dashboard and refresh existing catalog styling

## Testing
- npm run build
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d6b1d71bd4832a9b8d46c7a0d86c53