### PR TITLE
Improve supermarket pricing support and shopping list UX

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -53,6 +53,7 @@ class ProductController extends Controller
                         'section_id' => $item->supermarket_section_id,
                         'section_name' => optional($item->section)->name,
                         'section_position' => optional($item->section)->position,
+                        'price' => $item->price,
                     ];
                 })->values(),
             ];
@@ -104,8 +105,10 @@ class ProductController extends Controller
             'brand' => ['nullable', 'string', 'max:255'],
             'unit' => ['nullable', 'string', 'max:50'],
             'package_size' => ['nullable', 'string', 'max:255'],
-            'average_price' => ['nullable', 'numeric', 'min:0'],
             'description' => ['nullable', 'string'],
+            'inventories' => ['array'],
+            'inventories.*.supermarket_id' => ['required_with:inventories.*.price', 'exists:supermarkets,id'],
+            'inventories.*.price' => ['nullable', 'numeric', 'min:0'],
         ]);
 
         $slug = Str::slug($data['name']);
@@ -116,16 +119,18 @@ class ProductController extends Controller
             $slug .= '-' . Str::random(6);
         }
 
-        Product::create([
+        $product = Product::create([
             'product_category_id' => $data['product_category_id'],
             'name' => $data['name'],
             'slug' => $slug,
             'brand' => Arr::get($data, 'brand'),
             'unit' => Arr::get($data, 'unit'),
             'package_size' => Arr::get($data, 'package_size'),
-            'average_price' => Arr::get($data, 'average_price'),
             'description' => Arr::get($data, 'description'),
         ]);
+
+        $this->syncInventoryData($product, $data['inventories'] ?? []);
+        $this->refreshAveragePrice($product);
 
         return redirect()
             ->route('products.index')
@@ -140,8 +145,10 @@ class ProductController extends Controller
             'brand' => ['nullable', 'string', 'max:255'],
             'unit' => ['nullable', 'string', 'max:50'],
             'package_size' => ['nullable', 'string', 'max:255'],
-            'average_price' => ['nullable', 'numeric', 'min:0'],
             'description' => ['nullable', 'string'],
+            'inventories' => ['array'],
+            'inventories.*.supermarket_id' => ['required_with:inventories.*.price', 'exists:supermarkets,id'],
+            'inventories.*.price' => ['nullable', 'numeric', 'min:0'],
         ]);
 
         $product->fill($data);
@@ -151,6 +158,9 @@ class ProductController extends Controller
         }
 
         $product->save();
+
+        $this->syncInventoryData($product, $data['inventories'] ?? []);
+        $this->refreshAveragePrice($product);
 
         if ($request->expectsJson()) {
             $product->refresh();
@@ -189,6 +199,7 @@ class ProductController extends Controller
             'sections' => ['array'],
             'sections.*.supermarket_id' => ['required', 'exists:supermarkets,id'],
             'sections.*.section_id' => ['nullable', 'exists:supermarket_sections,id'],
+            'sections.*.price' => ['nullable', 'numeric', 'min:0'],
         ]);
 
         $sections = collect($data['sections'] ?? [])
@@ -203,24 +214,72 @@ class ProductController extends Controller
             foreach ($sections as $entry) {
                 $supermarketId = $entry['supermarket_id'];
                 $sectionId = $entry['section_id'];
+                $price = Arr::get($entry, 'price');
                 $inventoryItem = $inventoryItems->get($supermarketId);
 
+                $payload = [
+                    'supermarket_section_id' => $sectionId,
+                    'price' => $price !== null ? (float) $price : null,
+                ];
+
                 if ($inventoryItem) {
-                    $inventoryItem->update([
-                        'supermarket_section_id' => $sectionId,
-                    ]);
+                    $inventoryItem->update($payload);
                 } else {
-                    InventoryItem::create([
+                    InventoryItem::create(array_merge([
                         'product_id' => $product->id,
                         'supermarket_id' => $supermarketId,
-                        'supermarket_section_id' => $sectionId,
-                    ]);
+                    ], $payload));
                 }
             }
+
+            $this->refreshAveragePrice($product);
         });
 
         return redirect()
             ->route('products.index', ['search' => $request->input('search')])
             ->with('status', 'Pasillos actualizados.');
+    }
+
+    private function syncInventoryData(Product $product, array $inventories): void
+    {
+        if ($inventories === []) {
+            return;
+        }
+
+        $existing = $product->inventoryItems()->get()->keyBy('supermarket_id');
+
+        foreach ($inventories as $entry) {
+            $supermarketId = isset($entry['supermarket_id']) ? (int) $entry['supermarket_id'] : null;
+
+            if (! $supermarketId) {
+                continue;
+            }
+
+            $price = Arr::get($entry, 'price');
+
+            $payload = [
+                'price' => $price !== null ? (float) $price : null,
+            ];
+
+            $record = $existing->get($supermarketId);
+
+            if ($record) {
+                $record->update($payload);
+            } else {
+                InventoryItem::create(array_merge([
+                    'product_id' => $product->id,
+                    'supermarket_id' => $supermarketId,
+                ], $payload));
+            }
+        }
+    }
+
+    private function refreshAveragePrice(Product $product): void
+    {
+        $average = $product->inventoryItems()
+            ->whereNotNull('price')
+            ->avg('price');
+
+        $product->update(['average_price' => $average]);
     }
 }

--- a/app/Http/Controllers/ShoppingListController.php
+++ b/app/Http/Controllers/ShoppingListController.php
@@ -61,6 +61,7 @@ class ShoppingListController extends Controller
                         'section_id' => $item->supermarket_section_id,
                         'section_name' => optional($item->section)->name,
                         'section_position' => optional($item->section)->position,
+                        'price' => $item->price,
                     ];
                 })->values(),
             ];
@@ -361,6 +362,7 @@ class ShoppingListController extends Controller
                         'section_id' => $item->supermarket_section_id,
                         'section_name' => optional($item->section)->name,
                         'section_position' => optional($item->section)->position,
+                        'price' => $item->price,
                     ];
                 })->values(),
             ];
@@ -395,6 +397,19 @@ class ShoppingListController extends Controller
             'supermarketDataset' => $supermarketDataset,
             'sectionDataset' => $sectionDataset,
         ]);
+    }
+
+    public function destroy(Request $request, ShoppingList $shoppingList): RedirectResponse
+    {
+        if ((int) $shoppingList->user_id !== (int) $request->user()->id) {
+            abort(403);
+        }
+
+        $shoppingList->delete();
+
+        return redirect()
+            ->route('shopping-lists.index')
+            ->with('status', 'Lista eliminada correctamente.');
     }
 
     private function refreshListOrderingAndTotals(ShoppingList $shoppingList): void

--- a/app/Http/Controllers/ShoppingListItemStatusController.php
+++ b/app/Http/Controllers/ShoppingListItemStatusController.php
@@ -11,7 +11,7 @@ class ShoppingListItemStatusController extends Controller
 {
     public function __invoke(Request $request, ShoppingList $shoppingList, ShoppingListItem $shoppingListItem): RedirectResponse
     {
-        if ($shoppingList->user_id !== $request->user()->id || $shoppingListItem->shopping_list_id !== $shoppingList->id) {
+        if ((int) $shoppingList->user_id !== (int) $request->user()->id || (int) $shoppingListItem->shopping_list_id !== (int) $shoppingList->id) {
             abort(403);
         }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -503,10 +503,12 @@ class ListBuilder {
     collectExistingForms() {
         return Array.from(this.root.querySelectorAll('[data-existing-block]')).map((container) => ({
             container,
-            select: container.querySelector('[data-existing-product]'),
+            input: container.querySelector('[data-existing-input]'),
+            productId: container.querySelector('[data-existing-product]'),
+            options: container.querySelector('[data-existing-options]'),
             quantity: container.querySelector('[data-existing-quantity]'),
             notes: container.querySelector('[data-existing-notes]'),
-            filter: container.querySelector('[data-existing-filter]'),
+            supermarket: container.querySelector('[data-existing-supermarket]'),
         }));
     }
 
@@ -589,10 +591,36 @@ class ListBuilder {
         });
 
         this.existingForms.forEach((form) => {
-            form.select?.addEventListener('change', () => this.handleExistingSelection(form));
-            form.filter?.addEventListener('input', () => this.filterExistingOptions(form));
+            form.input?.addEventListener('focus', () => this.showExistingOptions(form));
+            form.input?.addEventListener('input', () => this.renderExistingOptions(form));
+            form.input?.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    this.selectFirstExistingOption(form);
+                }
+            });
 
-            this.applyExistingFilters(form);
+            form.options?.addEventListener('mousedown', (event) => {
+                const target = event.target;
+
+                if (! (target instanceof HTMLElement)) {
+                    return;
+                }
+
+                const productId = this.parseNullableInt(target.dataset.productId);
+
+                if (! productId) {
+                    return;
+                }
+
+                const product = this.productById.get(productId);
+
+                if (product) {
+                    this.handleExistingSelection(form, product);
+                }
+            });
+
+            this.renderExistingOptions(form);
         });
 
         this.manualForms.forEach((form) => {
@@ -635,10 +663,9 @@ class ListBuilder {
 
         const form = this.existingForms[0];
 
-        if (form?.filter) {
-            form.filter.focus();
-        } else if (form?.select) {
-            form.select.focus();
+        if (form?.input) {
+            form.input.focus();
+            this.showExistingOptions(form);
         }
     }
 
@@ -655,48 +682,78 @@ class ListBuilder {
         }
     }
 
-    filterExistingOptions(form) {
-        this.applyExistingFilters(form);
+    showExistingOptions(form) {
+        this.renderExistingOptions(form);
+        form.options?.classList.remove('hidden');
     }
 
-    applyExistingFilters(form) {
-        const select = form.select;
+    renderExistingOptions(form) {
+        const optionsContainer = form.options;
 
-        if (! select) {
+        if (! optionsContainer) {
             return;
         }
 
-        const query = form.filter?.value?.trim().toLowerCase() ?? '';
+        const query = form.input?.value?.trim().toLowerCase() ?? '';
+        const matches = this.products
+            .filter((product) => {
+                const name = product.name?.toLowerCase() ?? '';
+                const brand = product.brand?.toLowerCase() ?? '';
 
-        Array.from(select.options).forEach((option, index) => {
-            if (index === 0) {
-                option.hidden = false;
-                return;
-            }
+                return query === '' || name.includes(query) || brand.includes(query);
+            })
+            .slice(0, 30);
 
-            const text = option.textContent?.toLowerCase() ?? '';
-            const matchesQuery = query === '' || text.includes(query);
-            option.hidden = ! matchesQuery;
+        optionsContainer.innerHTML = '';
+
+        if (matches.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'px-3 py-2 text-xs text-slate-500';
+            empty.textContent = 'Sin coincidencias';
+            optionsContainer.appendChild(empty);
+            optionsContainer.classList.remove('hidden');
+            return;
+        }
+
+        matches.forEach((product) => {
+            const option = document.createElement('button');
+            option.type = 'button';
+            option.dataset.productId = product.id;
+            option.className = 'block w-full text-left px-3 py-2 hover:bg-indigo-50 text-sm';
+            option.innerHTML = `
+                <span class="font-semibold text-slate-800">${this.escapeHtml(product.name)}</span>
+                ${product.brand ? `<span class="text-xs text-slate-500"> · ${this.escapeHtml(product.brand)}</span>` : ''}
+            `;
+            optionsContainer.appendChild(option);
         });
+
+        optionsContainer.classList.remove('hidden');
     }
 
-    handleExistingSelection(form) {
-        if (! form.select) {
+    selectFirstExistingOption(form) {
+        const first = form.options?.querySelector('[data-product-id]');
+
+        if (! (first instanceof HTMLElement)) {
             return;
         }
 
-        const productId = this.parseNullableInt(form.select.value);
+        const productId = this.parseNullableInt(first.dataset.productId);
         const product = productId ? this.productById.get(productId) : null;
 
+        if (product) {
+            this.handleExistingSelection(form, product);
+        }
+    }
+
+    handleExistingSelection(form, product) {
         if (! product) {
             return;
         }
 
         const quantity = form.quantity ? Number.parseFloat(form.quantity.value || '1') || 1 : 1;
         const notes = form.notes?.value?.trim() || null;
-
-        const supermarketId = this.resolveDefaultSupermarketId(product);
-        const inventoryEntry = this.resolveInventoryEntry(product, supermarketId);
+        const chosenSupermarketId = this.parseNullableInt(form.supermarket?.value) ?? this.resolveDefaultSupermarketId(product);
+        const inventoryEntry = this.resolveInventoryEntry(product, chosenSupermarketId);
 
         const item = {
             type: 'existing',
@@ -710,20 +767,24 @@ class ListBuilder {
             package_size: product.package_size ?? null,
             quantity,
             quantity_unit: product.unit ?? '',
-            estimated_price: this.parsePrice(product.average_price) ?? null,
-            supermarket_id: supermarketId,
-            supermarket_name: this.resolveSupermarketName(supermarketId),
+            estimated_price: this.parsePrice(inventoryEntry?.price) ?? this.parsePrice(product.average_price) ?? null,
+            supermarket_id: chosenSupermarketId,
+            supermarket_name: this.resolveSupermarketName(chosenSupermarketId),
             section_id: inventoryEntry?.section_id ?? null,
             section_name: inventoryEntry?.section_name ?? null,
             section_number: inventoryEntry?.section_position ?? null,
             notes,
         };
 
+        if (form.productId) {
+            form.productId.value = String(product.id);
+        }
+
         this.items.push(item);
         this.render();
 
-        if (form.select) {
-            form.select.value = '';
+        if (form.input) {
+            form.input.value = '';
         }
 
         if (form.notes) {
@@ -732,6 +793,10 @@ class ListBuilder {
 
         if (form.quantity) {
             form.quantity.value = '1';
+        }
+
+        if (form.options) {
+            form.options.classList.add('hidden');
         }
     }
 

--- a/resources/views/components/product-modals/create.blade.php
+++ b/resources/views/components/product-modals/create.blade.php
@@ -1,4 +1,4 @@
-@props(['categories'])
+@props(['categories', 'supermarkets'])
 
 <div data-modal="create-product" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
     <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
@@ -38,14 +38,35 @@
                     <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-package">Presentación</label>
                     <input id="create-package" name="package_size" type="text" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Bolsa 1 kg">
                 </div>
-                <div>
-                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-price">Precio promedio</label>
-                    <input id="create-price" name="average_price" type="number" step="0.01" min="0" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="120.00">
-                </div>
                 <div class="md:col-span-2">
                     <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-description">Descripción</label>
                     <textarea id="create-description" name="description" rows="3" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Notas para reconocer el producto"></textarea>
                 </div>
+            </div>
+
+            <div class="border-t border-slate-100 pt-4">
+                <p class="text-sm font-semibold text-slate-700 mb-3">Precios por establecimiento</p>
+                <div class="grid gap-3 md:grid-cols-2">
+                    @foreach($supermarkets as $supermarket)
+                        <div class="border border-slate-200 rounded-lg p-3 space-y-2">
+                            <p class="text-sm font-semibold text-slate-700">{{ $supermarket->name }}</p>
+                            <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1" for="create-price-{{ $supermarket->id }}">Precio</label>
+                                <input
+                                    id="create-price-{{ $supermarket->id }}"
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    name="inventories[{{ $loop->index }}][price]"
+                                    class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                    placeholder="Ingresa el precio"
+                                >
+                            </div>
+                            <input type="hidden" name="inventories[{{ $loop->index }}][supermarket_id]" value="{{ $supermarket->id }}">
+                        </div>
+                    @endforeach
+                </div>
+                <p class="text-xs text-slate-500 mt-2">Usaremos estos precios para calcular el promedio y sugerir costos en las listas.</p>
             </div>
 
             <div class="flex items-center justify-end gap-3">

--- a/resources/views/components/product-modals/edit.blade.php
+++ b/resources/views/components/product-modals/edit.blade.php
@@ -1,4 +1,4 @@
-@props(['product', 'categories', 'searchTerm' => null])
+@props(['product', 'categories', 'supermarkets', 'searchTerm' => null])
 
 <div data-modal="edit-product-{{ $product->id }}" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
     <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
@@ -39,14 +39,38 @@
                     <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-package-{{ $product->id }}">Presentación</label>
                     <input id="edit-package-{{ $product->id }}" name="package_size" type="text" value="{{ old('package_size', $product->package_size) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                 </div>
-                <div>
-                    <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-price-{{ $product->id }}">Precio promedio</label>
-                    <input id="edit-price-{{ $product->id }}" name="average_price" type="number" step="0.01" min="0" value="{{ old('average_price', $product->average_price) }}" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                </div>
                 <div class="md:col-span-2">
                     <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-description-{{ $product->id }}">Descripción</label>
                     <textarea id="edit-description-{{ $product->id }}" name="description" rows="3" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">{{ old('description', $product->description) }}</textarea>
                 </div>
+            </div>
+
+            <div class="border-t border-slate-100 pt-4">
+                <p class="text-sm font-semibold text-slate-700 mb-3">Precios por establecimiento</p>
+                <div class="grid gap-3 md:grid-cols-2">
+                    @foreach($supermarkets as $supermarket)
+                        @php
+                            $inventory = $product->inventoryItems->firstWhere('supermarket_id', $supermarket->id);
+                        @endphp
+                        <div class="border border-slate-200 rounded-lg p-3 space-y-2">
+                            <p class="text-sm font-semibold text-slate-700">{{ $supermarket->name }}</p>
+                            <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1" for="edit-price-{{ $product->id }}-{{ $supermarket->id }}">Precio</label>
+                                <input
+                                    id="edit-price-{{ $product->id }}-{{ $supermarket->id }}"
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    name="inventories[{{ $loop->index }}][price]"
+                                    value="{{ old("inventories.$loop->index.price", optional($inventory)->price) }}"
+                                    class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                >
+                            </div>
+                            <input type="hidden" name="inventories[{{ $loop->index }}][supermarket_id]" value="{{ $supermarket->id }}">
+                        </div>
+                    @endforeach
+                </div>
+                <p class="text-xs text-slate-500 mt-2">Actualiza los precios para recalcular el promedio del producto.</p>
             </div>
 
             <div class="flex items-center justify-end gap-3">

--- a/resources/views/components/product-modals/sections.blade.php
+++ b/resources/views/components/product-modals/sections.blade.php
@@ -43,6 +43,18 @@
                                 </select>
                             </div>
                             <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1" for="section-price-{{ $product->id }}-{{ $supermarket->id }}">Precio</label>
+                                <input
+                                    id="section-price-{{ $product->id }}-{{ $supermarket->id }}"
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    name="sections[{{ $loop->index }}][price]"
+                                    value="{{ old("sections.$loop->index.price", optional($inventory)->price) }}"
+                                    class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                >
+                            </div>
+                            <div>
                                 <label class="block text-xs font-semibold text-slate-500 mb-1">Descripción actual</label>
                                 <div class="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-600 bg-slate-50">
                                     {{ $currentSection ? 'Pasillo ' . $currentSection->position . ' · ' . $currentSection->name : 'Sin registro' }}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -110,7 +110,7 @@
                     </footer>
                 </article>
 
-                <x-product-modals.edit :product="$product" :categories="$categories" :search-term="$searchTerm" />
+                <x-product-modals.edit :product="$product" :categories="$categories" :supermarkets="$supermarkets" :search-term="$searchTerm" />
                 <x-product-modals.sections :product="$product" :supermarkets="$supermarkets" :search-term="$searchTerm" />
             @empty
                 <div class="md:col-span-2 xl:col-span-3 bg-white border border-dashed border-slate-300 rounded-xl p-10 text-center">
@@ -119,7 +119,7 @@
             @endforelse
         </div>
 
-        <x-product-modals.create :categories="$categories" />
+        <x-product-modals.create :categories="$categories" :supermarkets="$supermarkets" />
         <x-product-modals.add-to-list :active-lists="$activeLists" :has-active-lists="$hasActiveLists" />
     </div>
 @endsection

--- a/resources/views/shopping-lists/partials/item-builder.blade.php
+++ b/resources/views/shopping-lists/partials/item-builder.blade.php
@@ -48,15 +48,19 @@
                 <h3 class="text-sm font-semibold text-slate-700 mb-3">Catálogo existente</h3>
                 <div class="space-y-4">
                     <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y filtrar</label>
-                        <input type="text" data-existing-filter placeholder="Escribe para filtrar productos por nombre" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y seleccionar producto</label>
+                        <div class="relative" data-existing-combobox>
+                            <input type="text" data-existing-input placeholder="Escribe para buscar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" autocomplete="off">
+                            <input type="hidden" data-existing-product>
+                            <div data-existing-options class="hidden absolute z-10 mt-1 w-full bg-white border border-slate-200 rounded-lg shadow max-h-60 overflow-y-auto"></div>
+                        </div>
                     </div>
                     <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>
-                        <select data-existing-product class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                            <option value="">-- Selecciona --</option>
-                            @foreach($products as $product)
-                                <option value="{{ $product->id }}">{{ $product->name }} @if($product->brand)· {{ $product->brand }}@endif</option>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
+                        <select data-existing-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <option value="">Igual al de la lista</option>
+                            @foreach($supermarkets as $market)
+                                <option value="{{ $market->id }}">{{ $market->name }}</option>
                             @endforeach
                         </select>
                     </div>
@@ -154,32 +158,36 @@
     </div>
 
     @if($isModalMode)
-        <div data-modal="builder-existing" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
-            <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
-                <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
-                    <div>
-                        <h3 class="text-lg font-semibold text-slate-800">Agregar desde catálogo</h3>
-                        <p class="text-xs text-slate-500">Selecciona un producto y se añadirá a la cola.</p>
-                    </div>
-                    <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
-                </div>
-                <div class="px-6 py-6 space-y-4" data-existing-block>
-                    <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y filtrar</label>
-                        <input type="text" data-existing-filter placeholder="Escribe para filtrar productos por nombre" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Selecciona producto</label>
-                        <select data-existing-product class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                            <option value="">-- Selecciona --</option>
-                            @foreach($products as $product)
-                                <option value="{{ $product->id }}">{{ $product->name }} @if($product->brand)· {{ $product->brand }}@endif</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="grid gap-4 sm:grid-cols-2">
+            <div data-modal="builder-existing" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 p-4">
+                <div class="bg-white rounded-2xl shadow-xl max-w-xl w-full overflow-hidden">
+                    <div class="flex items-center justify-between px-6 py-4 border-b border-slate-100">
                         <div>
-                            <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
+                            <h3 class="text-lg font-semibold text-slate-800">Agregar desde catálogo</h3>
+                            <p class="text-xs text-slate-500">Selecciona un producto y se añadirá a la cola.</p>
+                        </div>
+                        <button type="button" data-close-modal class="text-slate-400 hover:text-slate-600">✕</button>
+                    </div>
+                    <div class="px-6 py-6 space-y-4" data-existing-block>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Buscar y seleccionar producto</label>
+                            <div class="relative" data-existing-combobox>
+                                <input type="text" data-existing-input placeholder="Escribe para buscar" class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500" autocomplete="off">
+                                <input type="hidden" data-existing-product>
+                                <div data-existing-options class="hidden absolute z-10 mt-1 w-full bg-white border border-slate-200 rounded-lg shadow max-h-60 overflow-y-auto"></div>
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-slate-500 mb-1">Establecimiento</label>
+                            <select data-existing-supermarket class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                                <option value="">Igual al de la lista</option>
+                                @foreach($supermarkets as $market)
+                                    <option value="{{ $market->id }}">{{ $market->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label class="block text-xs font-medium text-slate-500 mb-1">Cantidad</label>
                             <input type="number" step="0.01" min="0.01" value="1" data-existing-quantity class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                         </div>
                         <div>

--- a/resources/views/shopping-lists/show.blade.php
+++ b/resources/views/shopping-lists/show.blade.php
@@ -27,6 +27,11 @@
                         {{ $shoppingList->status === 'active' ? 'Desactivar lista' : 'Activar lista' }}
                     </button>
                 </form>
+                <form method="POST" action="{{ route('shopping-lists.destroy', $shoppingList) }}" class="inline-flex items-center gap-2" onsubmit="return confirm('¿Eliminar esta lista de forma permanente?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-rose-300 text-rose-700 hover:bg-rose-50">Eliminar lista</button>
+                </form>
             </div>
         </div>
         <a href="{{ route('shopping-lists.index') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200">← Volver a todas las listas</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::middleware('auth')->group(function (): void {
 
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
-    Route::resource('shopping-lists', ShoppingListController::class)->only(['index', 'create', 'store', 'show']);
+    Route::resource('shopping-lists', ShoppingListController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::patch('shopping-lists/{shopping_list}', [ShoppingListController::class, 'update'])
         ->name('shopping-lists.update');
     Route::post('shopping-lists/{shopping_list}/items', [ShoppingListController::class, 'addItems'])


### PR DESCRIPTION
## Summary
- add per-supermarket price inputs to product create/edit flows and recalculate averages automatically
- enable selecting supermarkets when adding catalog items with a searchable combobox
- allow deleting shopping lists and fix forbidden error when moving items to cart

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445143a660832aa40831708e19d587)